### PR TITLE
Typo, dead link, invalid markdown.

### DIFF
--- a/dotnet-api/3.0.0/connecting-to-a-server.md
+++ b/dotnet-api/3.0.0/connecting-to-a-server.md
@@ -113,7 +113,7 @@ UserCredentials credentials = new UserCredentials("username","password");
 
 ### Security
 
-The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default). 
+The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default).
 
 To configure the client-side of the SSL connection, use the builder method below. For more information on setting up the server end of the Event Store for SSL, see [SSL Setup](/http-api/latest/setting-up-ssl-windows/).
 
@@ -168,7 +168,7 @@ When connecting to an Event Store HA cluster, you can specify that operations ca
 
 ### Handling Failures
 
-There following methods on the `ConnectionSettingsBuilder` allow you to modify the way in which the connection handles operation failures and connection issues.
+The following methods on the `ConnectionSettingsBuilder` allow you to modify the way in which the connection handles operation failures and connection issues.
 
 #### Reconnections
 

--- a/dotnet-api/3.0.0/stream-metadata.md
+++ b/dotnet-api/3.0.0/stream-metadata.md
@@ -126,7 +126,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
+            <td>The version of the metastream (see <a href="../optimistic-concurrency-and-idempotence">Expected Version</a>)</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>

--- a/dotnet-api/3.0.0/stream-metadata.md
+++ b/dotnet-api/3.0.0/stream-metadata.md
@@ -4,11 +4,11 @@ section: ".NET API"
 version: 3.0.0
 ---
 
-Every stream in the Event Store has metadata associated with it. Internally, the metadata includes such information as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API. 
+Every stream in the Event Store has metadata associated with it. Internally, the metadata includes information such as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API.
 
 A common use case of information you may want to store in metadata is information associated with an event that is not part of the event. An example of this might be which user wrote the event? Which application server were they talking to? From what IP address did the request come from? This type of information is not part of the actual event but is metadata assocatiated with the event.
 
-Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs. 
+Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs.
 
 ## Methods
 
@@ -32,7 +32,7 @@ Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVe
 
 ## Reading Stream Metadata
 
-To read stream metadata over the dotnet client you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
+To read stream metadata over the .NET API you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata, the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
 
 ```csharp
 Task<StreamMetadataResult> GetStreamMetadataAsync(string stream, UserCredentials userCredentials = null)
@@ -126,7 +126,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](optimistic-concurrency-and-idempotency.md))</td>
+            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>
@@ -142,7 +142,7 @@ Reading metadata may require that you pass credentials if you have security enab
 
 ## Writing Metadata
 
-Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](optimistic-concurrency-and-idempotency.md) for further details.
+Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](../optimistic-concurrency-and-idempotence) for further details.
 
 ```csharp
 Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null)

--- a/dotnet-api/3.0.0/writing-to-a-stream.md
+++ b/dotnet-api/3.0.0/writing-to-a-stream.md
@@ -91,7 +91,7 @@ The members on `EventData` are:
 
 ## Appending to a stream in a single write
 
-The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner
+The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner.
 
 The parameters are:
 
@@ -105,11 +105,11 @@ The parameters are:
     <tbody>
         <tr>
             <td><code>string stream</code></td>
-            <td>the name of the stream to which to append.</td>
+            <td>The name of the stream to which to append.</td>
         </tr>
         <tr>
             <td><code>int expectedVersion</code></td>
-            <td>the version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
+            <td>The version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
         </tr>
         <tr>
             <td><code>bool IsJson</code></td>

--- a/dotnet-api/3.0.1/connecting-to-a-server.md
+++ b/dotnet-api/3.0.1/connecting-to-a-server.md
@@ -113,7 +113,7 @@ UserCredentials credentials = new UserCredentials("username","password");
 
 ### Security
 
-The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default). 
+The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default).
 
 To configure the client-side of the SSL connection, use the builder method below. For more information on setting up the server end of the Event Store for SSL, see [SSL Setup](/http-api/latest/setting-up-ssl-windows/).
 
@@ -168,7 +168,7 @@ When connecting to an Event Store HA cluster, you can specify that operations ca
 
 ### Handling Failures
 
-There following methods on the `ConnectionSettingsBuilder` allow you to modify the way in which the connection handles operation failures and connection issues.
+The following methods on the `ConnectionSettingsBuilder` allow you to modify the way in which the connection handles operation failures and connection issues.
 
 #### Reconnections
 

--- a/dotnet-api/3.0.1/stream-metadata.md
+++ b/dotnet-api/3.0.1/stream-metadata.md
@@ -125,7 +125,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
+            <td>The version of the metastream (see <a href="../optimistic-concurrency-and-idempotence">Expected Version</a>)</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>

--- a/dotnet-api/3.0.1/stream-metadata.md
+++ b/dotnet-api/3.0.1/stream-metadata.md
@@ -3,11 +3,11 @@ title: "Stream Metadata"
 section: ".NET API"
 version: 3.0.1
 ---
-Every stream in the Event Store has metadata associated with it. Internally, the metadata includes such information as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API. 
+Every stream in the Event Store has metadata associated with it. Internally, the metadata includes information such as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API.
 
 A common use case of information you may want to store in metadata is information associated with an event that is not part of the event. An example of this might be which user wrote the event? Which application server were they talking to? From what IP address did the request come from? This type of information is not part of the actual event but is metadata assocatiated with the event.
 
-Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs. 
+Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs.
 
 ## Methods
 
@@ -31,7 +31,7 @@ Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVe
 
 ## Reading Stream Metadata
 
-To read stream metadata over the dotnet client you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
+To read stream metadata over the .NET API you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata, the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
 
 ```csharp
 Task<StreamMetadataResult> GetStreamMetadataAsync(string stream, UserCredentials userCredentials = null)
@@ -125,7 +125,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](optimistic-concurrency-and-idempotency.md))</td>
+            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>
@@ -141,7 +141,7 @@ Reading metadata may require that you pass credentials if you have security enab
 
 ## Writing Metadata
 
-Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](optimistic-concurrency-and-idempotency.md) for further details.
+Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](../optimistic-concurrency-and-idempotence) for further details.
 
 ```csharp
 Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null)

--- a/dotnet-api/3.0.1/writing-to-a-stream.md
+++ b/dotnet-api/3.0.1/writing-to-a-stream.md
@@ -92,7 +92,7 @@ The members on `EventData` are:
 
 ## Appending to a stream in a single write
 
-The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner
+The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner.
 
 The parameters are:
 
@@ -106,11 +106,11 @@ The parameters are:
     <tbody>
         <tr>
             <td><code>string stream</code></td>
-            <td>the name of the stream to which to append.</td>
+            <td>The name of the stream to which to append.</td>
         </tr>
         <tr>
             <td><code>int expectedVersion</code></td>
-            <td>the version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
+            <td>The version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
         </tr>
         <tr>
             <td><code>bool IsJson</code></td>

--- a/dotnet-api/3.0.2-pre/connecting-to-a-server.md
+++ b/dotnet-api/3.0.2-pre/connecting-to-a-server.md
@@ -39,11 +39,11 @@ The static `Create` methods on `EventStoreConnection` are used to create a new c
         <tr>
             <td><code>Create(string connectionString)</code></td>
             <td>Connects to Event Store (see URIs below) with settings from connection string</td>
-        </tr>        
+        </tr>
         <tr>
             <td><code>(obsolete) Create(IPEndPoint tcpEndPoint)</code></td>
             <td>Connects to a single node with default settings</td>
-        </tr>        
+        </tr>
         <tr>
             <td><code>(obsolete) Create(ConnectionSettings settings, IPEndPoint tcpEndPoint)</code></td>
             <td>Connects to a single node with custom settings (see <a href="#customising-connection-settings">Customising Connection Settings</a>)</td>
@@ -203,7 +203,7 @@ The following values can be set using the connection string.
             <td>ConnectTo</td>
             <td>A URI in format described above to connect to</td>
             <td>The URI to connect to</td>
-        </tr>                       
+        </tr>
     </tbody>
 </table>
 
@@ -314,7 +314,7 @@ UserCredentials credentials = new UserCredentials("username","password");
 
 ### Security
 
-The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default). 
+The .NET API and Event Store can communicate either over SSL or an unencrypted channel (by default).
 
 To configure the client-side of the SSL connection, use the builder method below. For more information on setting up the server end of the Event Store for SSL, see [SSL Setup](/http-api/latest/setting-up-ssl-windows/).
 
@@ -369,7 +369,7 @@ When connecting to an Event Store HA cluster you can specify that operations can
 
 ### Handling Failures
 
-There following methods on the `ConnectionSettingsBuilder` allow you to modify the way the connection handles operation failures and connection issues.
+The following methods on the `ConnectionSettingsBuilder` allow you to modify the way the connection handles operation failures and connection issues.
 
 #### Reconnections
 

--- a/dotnet-api/3.0.2-pre/stream-metadata.md
+++ b/dotnet-api/3.0.2-pre/stream-metadata.md
@@ -4,11 +4,11 @@ section: ".NET API"
 version: "3.0.2 (pre-release)"
 ---
 
-Every stream in the Event Store has metadata associated with it. Internally, the metadata includes such information as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API. 
+Every stream in the Event Store has metadata associated with it. Internally, the metadata includes information such as the ACL of the stream and the maximum count and age for the events in the stream. Client code can also put information into stream metadata for use with projections or through the client API.
 
 A common use case of information you may want to store in metadata is information associated with an event that is not part of the event. An example of this might be which user wrote the event? Which application server were they talking to? From what IP address did the request come from? This type of information is not part of the actual event but is metadata assocatiated with the event.
 
-Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs. 
+Stream metadata is stored internally as JSON, and can be accessed over the HTTP APIs.
 
 ## Methods
 
@@ -32,7 +32,7 @@ Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVe
 
 ## Reading Stream Metadata
 
-To read stream metadata over the dotnet client you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
+To read stream metadata over the .NET API you can use methods found on the EventStoreConnection. The GetStreamMetadata methods have two mechanisms of being used. The first is to return you a fluent interface over the stream metadata, the second (GetStreamMetadataRaw) is to return you the raw JSON of the stream metadata.
 
 ```csharp
 Task<StreamMetadataResult> GetStreamMetadataAsync(string stream, UserCredentials userCredentials = null)
@@ -126,7 +126,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](optimistic-concurrency-and-idempotency.md))</td>
+            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>
@@ -142,7 +142,7 @@ Reading metadata may require that you pass credentials if you have security enab
 
 ## Writing Metadata
 
-Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](optimistic-concurrency-and-idempotency.md) for further details.
+Writing metadata can also be done in both a typed and a raw mechanism. When writing it is generally easier to use the typed mechanism. Both writing mechanisms also support an expectedVersion which works the same as on any stream and can be used to control concurrency see [Expected Version](../optimistic-concurrency-and-idempotence) for further details.
 
 ```csharp
 Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null)

--- a/dotnet-api/3.0.2-pre/stream-metadata.md
+++ b/dotnet-api/3.0.2-pre/stream-metadata.md
@@ -126,7 +126,7 @@ This will return a RawStreamMetadataResult. The fields on this result are:
         </tr>
         <tr>
             <td><code>int MetastreamVersion</code></td>
-            <td>The version of the metastream (see [Expected Version](../optimistic-concurrency-and-idempotence))</td>
+            <td>The version of the metastream (see <a href="../optimistic-concurrency-and-idempotence">Expected Version</a>)</td>
         </tr>
         <tr>
             <td><code>byte[] Metadata</code></td>

--- a/dotnet-api/3.0.2-pre/writing-to-a-stream.md
+++ b/dotnet-api/3.0.2-pre/writing-to-a-stream.md
@@ -92,7 +92,7 @@ The members on `EventData` are:
 
 ## Appending to a stream in a single write
 
-The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner
+The `AppendToStreamAsync` method writes events atomically to the end of a stream, working in an async manner.
 
 The parameters are:
 
@@ -106,11 +106,11 @@ The parameters are:
     <tbody>
         <tr>
             <td><code>string stream</code></td>
-            <td>the name of the stream to which to append.</td>
+            <td>The name of the stream to which to append.</td>
         </tr>
         <tr>
             <td><code>int expectedVersion</code></td>
-            <td>the version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
+            <td>The version at which we currently expect the stream to be in order that an optimistic concurrency check can be performed. This should either be a positive integer, or one of the constants `ExpectedVersion.NoStream`, `ExpectedVersion.EmptyStream`, or to disable the check, `ExpectedVersion.Any`. See [here](../optimistic-concurrency-and-idempotence) for a broader discussion of this.</code></td>
         </tr>
         <tr>
             <td><code>bool IsJson</code></td>


### PR DESCRIPTION
I was reading the .NET API docs, and spotted some mistakes, might as well fix them quickly:

 * Corrected a typo (*There* - *The*) and some casing
 * Corrected little grammar (*information such as*)
 * Use *.NET API* to be consistent with other pages
 * Fixed a dead link for Expected Version
 * Fixed a link in a table, markdown does not work in a table: https://github.com/senchalabs/jsduck/issues/410

For some reason I just noticed in the diff, my editor also removed some trailing whitespace. Since this didn't do any harm, I didn't spend time undoing it.
