### PR TITLE
Simplified homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,12 +16,6 @@ URLs for documentation pages are version-specific. If you want to share a link t
 - [http://docs.geteventstore.com/http-api/**3.0.0**/security](http://docs.geteventstore.com/http-api/3.0.0/security) always points to version 3.0.0.
 - [http://docs.geteventstore.com/http-api/**latest**/security](http://docs.geteventstore.com/http-api/latest/security) always points to the latest stable version.
 
-## Projections
-
-User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter (or equivalent as per the [Command Line Arguments](/server/latest/command-line-arguments) page).
-
-Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
-
 ## Related Blog Posts
 
 The following blog posts talk about the Event Store and may be useful for features that aren’t yet documented here. If you know of any others, please let us know! For more articles by Event Store visit our [blog](http://geteventstore.com/blog).

--- a/index.md
+++ b/index.md
@@ -3,31 +3,17 @@ title: "Documentation"
 layout: docs
 ---
 
-<p class="docs-lead">Event Store docs are hosted on GitHub. The repository is public, and <a href="https://github.com/eventstore/docs.geteventstore.com">it’s open to pull requests</a>. We’ve got a bunch of goodies ready to send out to people who make useful contributions.</p>
+<p class="docs-lead">Event Store docs are hosted on GitHub. The repository is public and <a href="https://github.com/eventstore/docs.geteventstore.com">it’s open to pull requests</a>. Contributions, corrections and feedback are all welcome.</p>
 
 ## Using These Docs
 
-If you’re new to Event Store and want to get started, read through the Introduction section. If you know what you are looking for use the navigation on the left (or top, in smaller browser windows) to find the section and version you are interested in.
+Read through the [Introduction](/introduction) section if you’re new to Event Store. If you know what you are looking for navigate to the section and version you need.
 
-### Sharing Links
-
-If you want to share a link to the documentation, you can either use the version-specific URL format or the “latest” URL format. For example:
-
-```
-http://docs.geteventstore.com/http-api/3.0.0/security
-```
-
-always points to the Security page for **version 3.0.0 of the HTTP API**.
-
-```
-http://docs.geteventstore.com/http-api/latest/security
-```
-
-always points to the Security page for the **latest version of the HTTP API**.
+URLs for documentation pages are version-specific. If you want to share a link that always points to the latest version of software you can replace the version number in the URL with “latest”. For example, `http://docs.g…e.com/http-api/3.0.0/security` would become `http://docs.g…e.com/http-api/latest/security`.
 
 ## Projections
 
-User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter (or equivalent as per the [command line arguments](/server/latest/command-line-arguments) page).
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter (or equivalent as per the [Command Line Arguments](/server/latest/command-line-arguments) page).
 
 Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
 
@@ -69,10 +55,13 @@ The following blog posts talk about the Event Store and may be useful for featur
 - [Part 12 - (Aside) Database storage and backing up](http://codeofrob.com/entries/evented-github-adventure---database-storage-and-backing-up.html)
 - [Part 13 - Sentiment analysis of github commits](http://codeofrob.com/entries/evented-github-adventure---sentiment-analysis-of-github-commits.html)
 
-There is also a [video of Greg Young’s “In The Brain” session](http://skillsmatter.com/podcast/design-architecture/event-store-as-a-read-model) recorded at SkillsMatter in London about using projections for Complex Event Processing.
-
 ### Other Posts
 
 - [Ensuring Writes](http://geteventstore.com/blog/20130301/ensuring-writes-multi-node-replication/) - describes how writing works in our commercial highly available product.
 - [The Cost of Creating a Stream](http://geteventstore.com/blog/20130210/the-cost-of-creating-a-stream/)
 - [Various Hash Implementations (BSD Licensed!)](http://geteventstore.com/blog/20120921/a-useful-piece-of-code-1/)
+
+## Videos
+
+- [Ouro’s 2nd Birthday](http://geteventstore.com/blog/20141112/video-of-ouros-2nd-birthday) introducing Event Store 3.0.0
+- [Greg Young’s “In The Brain” session](http://skillsmatter.com/podcast/design-architecture/event-store-as-a-read-model) about using projections for Complex Event Processing.

--- a/index.md
+++ b/index.md
@@ -28,37 +28,37 @@ The following blog posts talk about the Event Store and may be useful for featur
 
 ### Getting Started Series
 
-- [Part 1 - Introduction](http://geteventstore.com/blog/20130220/getting-started-part-1-introduction/)
-- [Part 2 - Implementing the CommonDomain repository interface](http://geteventstore.com/blog/20130220/getting-started-part-2-implementing-the-commondomain-repository-interface/)
-- [Part 3 - Subscriptions](http://geteventstore.com/blog/20130306/getting-started-part-3-subscriptions/)
+- [Part 1: Introduction](http://geteventstore.com/blog/20130220/getting-started-part-1-introduction/)
+- [Part 2: Implementing the CommonDomain repository interface](http://geteventstore.com/blog/20130220/getting-started-part-2-implementing-the-commondomain-repository-interface/)
+- [Part 3: Subscriptions](http://geteventstore.com/blog/20130306/getting-started-part-3-subscriptions/)
 
 ### Projections Series
 
-- [Part 1 - Projections Theory](http://geteventstore.com/blog/20130212/projections-1-theory/)
-- [Part 2 - A Simple SEP Projection](http://geteventstore.com/blog/20130213/projections-2-a-simple-sep-projection/)
-- [Part 3 - Using State](http://geteventstore.com/blog/20130215/projections-3-using-state/)
-- [Intermission - A Case Study](http://geteventstore.com/blog/20130217/projections-intermission/)
-- [Part 4 - Event Matching](http://geteventstore.com/blog/20130218/projections-4-event-matching/)
-- [Part 5 - Indexing](http://geteventstore.com/blog/20130218/projections-5-indexing/)
-- [Part 6 - An Indexing Use Case](http://geteventstore.com/blog/20130227/projections-6-an-indexing-use-case/)
-- [Part 7 - Multiple Streams](http://geteventstore.com/blog/20130309/projections-7-multiple-streams/)
-- [Part 8 - Internal Indexing](http://geteventstore.com/blog/20130309/projections-8-internal-indexing/)
+- [Part 1: Projections Theory](http://geteventstore.com/blog/20130212/projections-1-theory/)
+- [Part 2: A Simple SEP Projection](http://geteventstore.com/blog/20130213/projections-2-a-simple-sep-projection/)
+- [Part 3: Using State](http://geteventstore.com/blog/20130215/projections-3-using-state/)
+- [Intermission: A Case Study](http://geteventstore.com/blog/20130217/projections-intermission/)
+- [Part 4: Event Matching](http://geteventstore.com/blog/20130218/projections-4-event-matching/)
+- [Part 5: Indexing](http://geteventstore.com/blog/20130218/projections-5-indexing/)
+- [Part 6: An Indexing Use Case](http://geteventstore.com/blog/20130227/projections-6-an-indexing-use-case/)
+- [Part 7: Multiple Streams](http://geteventstore.com/blog/20130309/projections-7-multiple-streams/)
+- [Part 8: Internal Indexing](http://geteventstore.com/blog/20130309/projections-8-internal-indexing/)
 
 ### Rob Ashton’s Projections Series
 
-- [Part 1 - Introduction to the EventStore](http://codeofrob.com/entries/playing-with-the-eventstore.html)
-- [Part 2 - Pushing data into the EventStore](http://codeofrob.com/entries/pushing-data-into-streams-in-the-eventstore.html)
-- [Part 3 - Projections in the EventStore](http://codeofrob.com/entries/basic-projections-in-the-eventstore.html)
-- [Part 4 - Re-partitioning streams in the EventStore](http://codeofrob.com/entries/re-partitioning-streams-in-the-event-store-for-better-projections.html)
-- [Part 5 - Creating a projection per stream](http://codeofrob.com/entries/creating-a-projection-per-stream-in-the-eventstore.html)
-- [Part 6 - Pumping data from Github into the EventStore](http://codeofrob.com/entries/less-abstract,-pumping-data-from-github-into-the-eventstore.html)
-- [Part 7 - Emitting new events from a projection](http://codeofrob.com/entries/evented-github-adventure---emitting-commits-as-their-own-events.html)
-- [Part 8 - Who is the sweariest of them all?](http://codeofrob.com/entries/evented-github-adventure---who-writes-the-sweariest-commit-messages.html)
-- [Part 9 - Temporal queries in the event store](http://codeofrob.com/entries/evented-github-adventure---temporal-queries,-who-doesnt-trust-their-hardware.html)
-- [Part 10 - Projections from multiple streams](http://codeofrob.com/entries/evented-github-adventure---crossing-the-streams-to-gain-real-insights.html)
-- [Part 11 - Temporal averages](http://codeofrob.com/entries/evented-github-adventure---temporal-averages.html)
-- [Part 12 - (Aside) Database storage and backing up](http://codeofrob.com/entries/evented-github-adventure---database-storage-and-backing-up.html)
-- [Part 13 - Sentiment analysis of github commits](http://codeofrob.com/entries/evented-github-adventure---sentiment-analysis-of-github-commits.html)
+- [Part 1: Introduction to the EventStore](http://codeofrob.com/entries/playing-with-the-eventstore.html)
+- [Part 2: Pushing data into the EventStore](http://codeofrob.com/entries/pushing-data-into-streams-in-the-eventstore.html)
+- [Part 3: Projections in the EventStore](http://codeofrob.com/entries/basic-projections-in-the-eventstore.html)
+- [Part 4: Re-partitioning streams in the EventStore](http://codeofrob.com/entries/re-partitioning-streams-in-the-event-store-for-better-projections.html)
+- [Part 5: Creating a projection per stream](http://codeofrob.com/entries/creating-a-projection-per-stream-in-the-eventstore.html)
+- [Part 6: Pumping data from Github into the EventStore](http://codeofrob.com/entries/less-abstract,-pumping-data-from-github-into-the-eventstore.html)
+- [Part 7: Emitting new events from a projection](http://codeofrob.com/entries/evented-github-adventure---emitting-commits-as-their-own-events.html)
+- [Part 8: Who is the sweariest of them all?](http://codeofrob.com/entries/evented-github-adventure---who-writes-the-sweariest-commit-messages.html)
+- [Part 9: Temporal queries in the event store](http://codeofrob.com/entries/evented-github-adventure---temporal-queries,-who-doesnt-trust-their-hardware.html)
+- [Part 10: Projections from multiple streams](http://codeofrob.com/entries/evented-github-adventure---crossing-the-streams-to-gain-real-insights.html)
+- [Part 11: Temporal averages](http://codeofrob.com/entries/evented-github-adventure---temporal-averages.html)
+- [Part 12: (Aside) Database storage and backing up](http://codeofrob.com/entries/evented-github-adventure---database-storage-and-backing-up.html)
+- [Part 13: Sentiment analysis of github commits](http://codeofrob.com/entries/evented-github-adventure---sentiment-analysis-of-github-commits.html)
 
 ### Other Posts
 
@@ -68,5 +68,5 @@ The following blog posts talk about the Event Store and may be useful for featur
 
 ## Videos
 
-- [Ouro’s 2nd Birthday](http://geteventstore.com/blog/20141112/video-of-ouros-2nd-birthday) introducing Event Store 3.0.0
+- [Ouro’s 2nd Birthday](http://geteventstore.com/blog/20141112/video-of-ouros-2nd-birthday) introducing Event Store 3.0.0.
 - [Greg Young’s “In The Brain” session](http://skillsmatter.com/podcast/design-architecture/event-store-as-a-read-model) about using projections for Complex Event Processing.

--- a/index.md
+++ b/index.md
@@ -9,7 +9,9 @@ layout: docs
 
 Read through the [Introduction](/introduction) section if you’re new to Event Store. If you know what you are looking for navigate to the section and version you need.
 
-URLs for documentation pages are version-specific. If you want to share a link that always points to the latest version of software you can replace the version number in the URL with “latest”. For example, `http://docs.g…e.com/http-api/3.0.0/security` would become `http://docs.g…e.com/http-api/latest/security`.
+### A note on URLs
+
+URLs for documentation pages are version-specific. If you want to share a link that always points to the latest (non pre-release) version you can replace the version number in the URL with “latest”. For example http://docs.geteventstore.com/http-api/3.0.0/security would become http://docs.geteventstore.com/http-api/latest/security.
 
 ## Projections
 

--- a/index.md
+++ b/index.md
@@ -9,9 +9,12 @@ layout: docs
 
 Read through the [Introduction](/introduction) section if you’re new to Event Store. If you know what you are looking for navigate to the section and version you need.
 
-### A note on URLs
+### Sharing Links
 
-URLs for documentation pages are version-specific. If you want to share a link that always points to the latest (non pre-release) version you can replace the version number in the URL with “latest”. For example http://docs.geteventstore.com/http-api/3.0.0/security would become http://docs.geteventstore.com/http-api/latest/security.
+URLs for documentation pages are version-specific. If you want to share a link that always points to the latest (non pre-release) version you can replace the version number in the URL with “latest”. For example:
+
+- [http://docs.geteventstore.com/http-api/**3.0.0**/security](http://docs.geteventstore.com/http-api/3.0.0/security) always points to version 3.0.0.
+- [http://docs.geteventstore.com/http-api/**latest**/security](http://docs.geteventstore.com/http-api/latest/security) always points to the latest stable version.
 
 ## Projections
 

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ Projections are still experimental and as such we have not yet documented them h
 
 ## Related Blog Posts
 
-The following blog posts talk about the Event Store and may be useful for features that aren’t yet documented here. If you know of any others, please let us know!
+The following blog posts talk about the Event Store and may be useful for features that aren’t yet documented here. If you know of any others, please let us know! For more articles by Event Store visit our [blog](http://geteventstore.com/blog).
 
 ### Getting Started Series
 

--- a/server/3.0.0/command-line-arguments.md
+++ b/server/3.0.0/command-line-arguments.md
@@ -59,6 +59,10 @@ PREPARE TIMEOUT MS:       2000 (<DEFAULT>)
 COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
+<span class="note">
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+</span>
+
 The following parameters are supported by the Event Store:
 
 <table>

--- a/server/3.0.0/command-line-arguments.md
+++ b/server/3.0.0/command-line-arguments.md
@@ -60,7 +60,7 @@ COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
 <span class="note">
-User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used listed on the [docs homepage](/).
 </span>
 
 The following parameters are supported by the Event Store:

--- a/server/3.0.0/command-line-arguments.md
+++ b/server/3.0.0/command-line-arguments.md
@@ -8,7 +8,7 @@ The Event Store supports many configuration points. There are three distinct way
 
 To pass a configuration value over the command line you just add the configuration to the line executing the Event Store e.g. `EventStore.ClusterNode.exe --log ~/logs`
 
-While command line arguments tend to be very useful in development scenarios, they are often not the prefered way to handle configuration in a production system.
+While command line arguments tend to be very useful in development scenarios, they are often not the preferred way to handle configuration in a production system.
 
 All arguments can also be set as environment variables. This mechanism is often used in UNIX based systems.
 

--- a/server/3.0.1/command-line-arguments.md
+++ b/server/3.0.1/command-line-arguments.md
@@ -59,6 +59,10 @@ PREPARE TIMEOUT MS:       2000 (<DEFAULT>)
 COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
+<span class="note">
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+</span>
+
 The following parameters are supported by the Event Store:
 
 <table>

--- a/server/3.0.1/command-line-arguments.md
+++ b/server/3.0.1/command-line-arguments.md
@@ -60,7 +60,7 @@ COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
 <span class="note">
-User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used listed on the [docs homepage](/).
 </span>
 
 The following parameters are supported by the Event Store:

--- a/server/3.0.1/command-line-arguments.md
+++ b/server/3.0.1/command-line-arguments.md
@@ -8,7 +8,7 @@ The Event Store supports many configuration points. There are three distinct way
 
 To pass a configuration value over the command line you just add the configuration to the line executing the Event Store e.g. `EventStore.ClusterNode.exe --log ~/logs`
 
-While command line arguments tend to be very useful in development scenarios, they are often not the prefered way to handle configuration in a production system.
+While command line arguments tend to be very useful in development scenarios, they are often not the preferred way to handle configuration in a production system.
 
 All arguments can also be set as environment variables. This mechanism is often used in UNIX based systems.
 

--- a/server/3.0.2-pre/command-line-arguments.md
+++ b/server/3.0.2-pre/command-line-arguments.md
@@ -59,6 +59,10 @@ PREPARE TIMEOUT MS:       2000 (<DEFAULT>)
 COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
+<span class="note">
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+</span>
+
 The following parameters are supported by the Event Store:
 
 <table>

--- a/server/3.0.2-pre/command-line-arguments.md
+++ b/server/3.0.2-pre/command-line-arguments.md
@@ -60,7 +60,7 @@ COMMIT TIMEOUT MS:        2000 (<DEFAULT>)
 ```
 
 <span class="note">
-User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used, which are listed below under the Related Blog Posts section below.
+User projections are not enabled by default, however the projections engine is used internally for account management. If you want to run user projections, it is necessary to start using the `--run-projections=all` command line parameter.<br><br>Projections are still experimental and as such we have not yet documented them here. However, there are two series of blog posts about how they can be used listed on the [docs homepage](/).
 </span>
 
 The following parameters are supported by the Event Store:

--- a/server/3.0.2-pre/command-line-arguments.md
+++ b/server/3.0.2-pre/command-line-arguments.md
@@ -8,7 +8,7 @@ The Event Store supports many configuration points. There are three distinct way
 
 To pass a configuration value over the command line you just add the configuration to the line executing the Event Store e.g. `EventStore.ClusterNode.exe --log ~/logs`
 
-While command line arguments tend to be very useful in development scenarios, they are often not the prefered way to handle configuration in a production system.
+While command line arguments tend to be very useful in development scenarios, they are often not the preferred way to handle configuration in a production system.
 
 All arguments can also be set as environment variables. This mechanism is often used in UNIX based systems.
 


### PR DESCRIPTION
- Updated welcome message.
- Clarified URL format for shared links.
- Moved note on projections to the command line arguments page.
- Improved punctuation in lists.
- Moved videos to their own section, and added a link to Ouro’s 2nd Birthday blog post.

- Fixed a typo on the command line arguments page.