### PR TITLE
Fixed wrong links

### DIFF
--- a/http-api/3.0.0/creating-a-stream.md
+++ b/http-api/3.0.0/creating-a-stream.md
@@ -8,4 +8,4 @@ version: 3.0.0
 As of Event Store 2.0.0, there is no explicit stream creation operation, as there is no longer a `$StreamCreated` as the first event in every stream.
 </span>
 
-To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](./stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](./writing-to-a-stream).
+To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](../stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](../writing-to-a-stream).

--- a/http-api/3.0.1/creating-a-stream.md
+++ b/http-api/3.0.1/creating-a-stream.md
@@ -8,4 +8,4 @@ version: 3.0.1
 As of Event Store 2.0.0, there is no explicit stream creation operation, as there is no longer a `$StreamCreated` as the first event in every stream.
 </span>
 
-To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](./stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](./writing-to-a-stream).
+To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](../stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](../writing-to-a-stream).

--- a/http-api/3.0.2-pre/creating-a-stream.md
+++ b/http-api/3.0.2-pre/creating-a-stream.md
@@ -8,4 +8,4 @@ version: "3.0.2 (pre-release)"
 As of Event Store 2.0.0, there is no explicit stream creation operation, as there is no longer a `$StreamCreated` as the first event in every stream.
 </span>
 
-To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](./stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](./writing-to-a-stream).
+To set stream metadata (for example, an access control list or a maximum age or count of events), use the operations described in [Stream Metadata](../stream-metadata), and then post to the stream using the operations described in [Writing to a Stream)](../writing-to-a-stream).


### PR DESCRIPTION
Fixed some links that were using the wrong path when pointing to other
resources. Using "./resource" it navigated to the resource as a
subresource from where you were standing, but now using "../resource"
the links work as expected.