### PR TITLE
Adding GitHub links

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,5 +6,8 @@
         <div class="docs-content">
             <h1>{{ page.title }}</h1>
             {{ content }}
+            {% if page.title != "Documentation" %}
+            <p class="docs-lead">Event Store docs are hosted on <a href="https://github.com/eventstore/docs.geteventstore.com">GitHub</a>. The repository is public and it’s open to issues and pull requests. Contributions, corrections and feedback are all welcome.</p>
+            {% endif %}
         </div>
 {% include footer.html %}

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ title: "Documentation"
 layout: docs
 ---
 
-<p class="docs-lead">Event Store docs are hosted on GitHub. The <a href="https://github.com/eventstore/docs.geteventstore.com">repository</a> is public and it’s open to <a href="https://github.com/EventStore/docs.geteventstore.com/issues">issues</a> and <a href="https://github.com/EventStore/docs.geteventstore.com/pulls">pull requests</a>. Contributions, corrections and feedback are all welcome.</p>
+<p class="docs-lead">Event Store docs are hosted on <a href="https://github.com/eventstore/docs.geteventstore.com">GitHub</a>. The repository is public and it’s open to issues and pull requests. Contributions, corrections and feedback are all welcome.</p>
 
 ## Using These Docs
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ title: "Documentation"
 layout: docs
 ---
 
-<p class="docs-lead">Event Store docs are hosted on GitHub. The repository is public and <a href="https://github.com/eventstore/docs.geteventstore.com">it’s open to pull requests</a>. Contributions, corrections and feedback are all welcome.</p>
+<p class="docs-lead">Event Store docs are hosted on GitHub. The <a href="https://github.com/eventstore/docs.geteventstore.com">repository</a> is public and it’s open to <a href="https://github.com/EventStore/docs.geteventstore.com/issues">issues</a> and <a href="https://github.com/EventStore/docs.geteventstore.com/pulls">pull requests</a>. Contributions, corrections and feedback are all welcome.</p>
 
 ## Using These Docs
 


### PR DESCRIPTION
A section linking to the GitHub repo is now in the footer of every docs page. This will hopefully remind people that corrections and improvements can be made by anyone in the community.