### PR TITLE
Add metadata samples

### DIFF
--- a/http-api/3.0.3/stream-metadata.md
+++ b/http-api/3.0.3/stream-metadata.md
@@ -154,9 +154,8 @@ To update the metadata for a stream, a `POST` should be made to the metadata res
             "metaReadRole": "$all" 
         },
         "metadata": {
-            "$causationid": "a9a03400-1107-11e5-b939-0800200c9a66",
-            "$correlationid": "152c6630-1108-11e5-b939-0800200c9a66",
-            "bodyClrTypeName": "MyApp.Events.UserUpdated, MyApp.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+            "source": "some-service",
+            "otherInfo": "popcorn"
         }
     }
 ]

--- a/http-api/3.0.3/stream-metadata.md
+++ b/http-api/3.0.3/stream-metadata.md
@@ -152,6 +152,11 @@ To update the metadata for a stream, a `POST` should be made to the metadata res
         "data": {
             "readRole": "$all",
             "metaReadRole": "$all" 
+        },
+        "metadata": {
+            "$causationid": "a9a03400-1107-11e5-b939-0800200c9a66",
+            "$correlationid": "152c6630-1108-11e5-b939-0800200c9a66",
+            "bodyClrTypeName": "MyApp.Events.UserUpdated, MyApp.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
         }
     }
 ]

--- a/http-api/3.1.0-pre/writing-to-a-stream.md
+++ b/http-api/3.1.0-pre/writing-to-a-stream.md
@@ -113,7 +113,12 @@ The event store also supports a custom media type for posting events `applicatio
   {
     "eventId": "fbf4a1a1-b4a3-4dfe-a01f-ec52c34e16e4",
     "eventType": "event-type",
-    "data": { "a": "1" }
+    "data": { "a": "1" },
+     "metadata": {
+       "$causationid": "a9a03400-1107-11e5-b939-0800200c9a66",
+       "$correlationid": "152c6630-1108-11e5-b939-0800200c9a66",
+       "bodyClrTypeName": "MyApp.Events.UserUpdated, MyApp.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+    }
   }
 ]
 ```
@@ -130,6 +135,10 @@ or for XML
         <Something>1</Something>
       </MyEvent>
     </Data>
+    <MetaData>
+      <!-- not sure how this is supposed to look -->
+      <correlationid>152c6630-1108-11e5-b939-0800200c9a66</correlationid>
+    </Metadata>
   </Event>
 </Events>
 ```


### PR DESCRIPTION
this metadata.txt example doesn't actually contain any metadata.  In general, the documentation is lacking example metadata.  Understanding that metadata is use case specific, I do think it would be helpful to show some examples of what it looks like...  Here is one idea, but maybe the fields I chose are not generic enough or may add confusion without further explanation.
