### PR TITLE
Removed double word in index.md

### DIFF
--- a/dotnet-api/3.0.2/index.md
+++ b/dotnet-api/3.0.2/index.md
@@ -5,7 +5,7 @@ version: 3.0.2
 pinned: true
 ---
 
-The .NET Client API communicates with the Event Store using over TCP, using length-prefixed serialized protocol buffers. The API allows for reading and writing operations, as well as for subscriptions to individual event streams or all events written.
+The .NET Client API communicates with the Event Store over TCP, using length-prefixed serialized protocol buffers. The API allows for reading and writing operations, as well as for subscriptions to individual event streams or all events written.
 
 ## EventStoreConnection
 


### PR DESCRIPTION
Removed double word in the .net version of index.md

A tiny improvement, since it can probably be merged by clicking just one button I thought I'd create a pull request for it anyway :). Let me know if you're looking for these kinds of contributions or if its just generating noise for you.