### PR TITLE
Add projection docs to newer versions of the .Net api

### DIFF
--- a/dotnet-api/3.1.0/projections.md
+++ b/dotnet-api/3.1.0/projections.md
@@ -1,0 +1,85 @@
+---
+title: "Projections Management"
+section: ".NET API"
+version: "3.1.0"
+---
+
+**PROJECTIONS ARE STILL IN BETA THIS DOCUMENTATION IS SUBJECT TO CHANGE WITHOUT NOTICE
+
+The Event Store Client API includes some helper methods that use the HTTP API to allow for the management of projections in the system. This document will describe the methods found in the ProjectionsManager class (in addition to the XML docs already on it). Note all methods in this class are async.
+
+## Methods
+
+### Enable a Projection
+
+Enables an existing projection by its name. You must have access to a projection in order to enable it.
+
+```csharp
+        public Task EnableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Disable a Projection
+
+Disables an existing projection by its name. You must have access to a projection in order to disable it.
+
+```csharp
+        public Task DisableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Abort a Projection
+
+Aborts an existing projection by its name. You must have access to a projection in order to abort it.
+
+```csharp
+        public Task AbortAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Create a One-Time Projection
+
+Creates a projection that will run until the end of the log and then stop. The query parameter contains the javascript you want to be created as a one time projection.
+
+```csharp
+        public Task CreateOneTimeAsync(string query, UserCredentials userCredentials = null)
+```
+
+### Create a Continuous Projection
+
+Creates a projection that will run until the end of the log and then continue running. The query parameter contains the javascript you want to be created as a one time projection. Continuous projections have explicit names and can be enabled/disabled via this name
+
+```csharp
+        public Task CreateContinuousAsync(string name, string query, UserCredentials userCredentials = null)
+```
+
+### List all Projections
+
+Returns a list of all the projections in the system.
+//TODO make this return objects.
+
+```csharp
+        public Task<string> ListAllAsync(UserCredentials userCredentials = null)
+```
+
+### List One-Time Projections
+
+Returns a list of all One-Time Projections in the system
+//TODO make this return objects.
+
+```csharp
+        public Task<string> ListOneTimeAsync(UserCredentials userCredentials = null)
+```
+
+### Get Statistics on Projection
+
+Returns the statistics associated with a named projection
+
+```csharp
+        public Task<string> GetStatisticsAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Delete Projection
+
+Deletes a named projection. You must have access to a projection in order to delete it.
+
+```csharp
+        public Task DeleteAsync(string name, UserCredentials userCredentials = null)
+```

--- a/dotnet-api/3.2.0/projections.md
+++ b/dotnet-api/3.2.0/projections.md
@@ -1,7 +1,7 @@
 ---
 title: "Projections Management"
 section: ".NET API"
-version: "3.1.0 (pre-release)"
+version: "3.2.0"
 ---
 
 **PROJECTIONS ARE STILL IN BETA THIS DOCUMENTATION IS SUBJECT TO CHANGE WITHOUT NOTICE
@@ -54,6 +54,7 @@ Creates a projection that will run until the end of the log and then continue ru
 
 Returns a list of all the projections in the system.
 //TODO make this return objects.
+
 ```csharp
         public Task<string> ListAllAsync(UserCredentials userCredentials = null)
 ```
@@ -61,7 +62,8 @@ Returns a list of all the projections in the system.
 ### List One-Time Projections
 
 Returns a list of all One-Time Projections in the system
-//TODO make this return objects
+//TODO make this return objects.
+
 ```csharp
         public Task<string> ListOneTimeAsync(UserCredentials userCredentials = null)
 ```

--- a/dotnet-api/3.3.1/projections.md
+++ b/dotnet-api/3.3.1/projections.md
@@ -1,0 +1,85 @@
+---
+title: "Projections Management"
+section: ".NET API"
+version: "3.3.1"
+---
+
+**PROJECTIONS ARE STILL IN BETA THIS DOCUMENTATION IS SUBJECT TO CHANGE WITHOUT NOTICE
+
+The Event Store Client API includes some helper methods that use the HTTP API to allow for the management of projections in the system. This document will describe the methods found in the ProjectionsManager class (in addition to the XML docs already on it). Note all methods in this class are async.
+
+## Methods
+
+### Enable a Projection
+
+Enables an existing projection by its name. You must have access to a projection in order to enable it.
+
+```csharp
+        public Task EnableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Disable a Projection
+
+Disables an existing projection by its name. You must have access to a projection in order to disable it.
+
+```csharp
+        public Task DisableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Abort a Projection
+
+Aborts an existing projection by its name. You must have access to a projection in order to abort it.
+
+```csharp
+        public Task AbortAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Create a One-Time Projection
+
+Creates a projection that will run until the end of the log and then stop. The query parameter contains the javascript you want to be created as a one time projection.
+
+```csharp
+        public Task CreateOneTimeAsync(string query, UserCredentials userCredentials = null)
+```
+
+### Create a Continuous Projection
+
+Creates a projection that will run until the end of the log and then continue running. The query parameter contains the javascript you want to be created as a one time projection. Continuous projections have explicit names and can be enabled/disabled via this name
+
+```csharp
+        public Task CreateContinuousAsync(string name, string query, UserCredentials userCredentials = null)
+```
+
+### List all Projections
+
+Returns a list of all the projections in the system.
+//TODO make this return objects.
+
+```csharp
+        public Task<string> ListAllAsync(UserCredentials userCredentials = null)
+```
+
+### List One-Time Projections
+
+Returns a list of all One-Time Projections in the system
+//TODO make this return objects.
+
+```csharp
+        public Task<string> ListOneTimeAsync(UserCredentials userCredentials = null)
+```
+
+### Get Statistics on Projection
+
+Returns the statistics associated with a named projection
+
+```csharp
+        public Task<string> GetStatisticsAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Delete Projection
+
+Deletes a named projection. You must have access to a projection in order to delete it.
+
+```csharp
+        public Task DeleteAsync(string name, UserCredentials userCredentials = null)
+```

--- a/dotnet-api/3.4.0/projections.md
+++ b/dotnet-api/3.4.0/projections.md
@@ -1,0 +1,83 @@
+---
+title: "Projections Management"
+section: ".NET API"
+version: "3.4.0"
+---
+
+**PROJECTIONS ARE STILL IN BETA THIS DOCUMENTATION IS SUBJECT TO CHANGE WITHOUT NOTICE
+
+The Event Store Client API includes some helper methods that use the HTTP API to allow for the management of projections in the system. This document will describe the methods found in the ProjectionsManager class (in addition to the XML docs already on it). Note all methods in this class are async.
+
+## Methods
+
+### Enable a Projection
+
+Enables an existing projection by its name. You must have access to a projection in order to enable it.
+
+```csharp
+        public Task EnableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Disable a Projection
+
+Disables an existing projection by its name. You must have access to a projection in order to disable it.
+
+```csharp
+        public Task DisableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Abort a Projection
+
+Aborts an existing projection by its name. You must have access to a projection in order to abort it.
+
+```csharp
+        public Task AbortAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Create a One-Time Projection
+
+Creates a projection that will run until the end of the log and then stop. The query parameter contains the javascript you want to be created as a one time projection.
+
+```csharp
+        public Task CreateOneTimeAsync(string query, UserCredentials userCredentials = null)
+```
+
+### Create a Continuous Projection
+
+Creates a projection that will run until the end of the log and then continue running. The query parameter contains the javascript you want to be created as a one time projection. Continuous projections have explicit names and can be enabled/disabled via this name
+
+```csharp
+        public Task CreateContinuousAsync(string name, string query, UserCredentials userCredentials = null)
+```
+
+### List all Projections
+
+Returns a list of all the projections in the system.
+
+```csharp
+        public Task<List<ProjectionDetails>> ListAllAsync(UserCredentials userCredentials = null)
+```
+
+### List One-Time Projections
+
+Returns a list of all One-Time Projections in the system
+
+```csharp
+        public Task<List<ProjectionDetails>> ListOneTimeAsync(UserCredentials userCredentials = null)
+```
+
+### Get Statistics on Projection
+
+Returns the statistics associated with a named projection
+
+```csharp
+        public Task<string> GetStatisticsAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Delete Projection
+
+Deletes a named projection. You must have access to a projection in order to delete it.
+
+```csharp
+        public Task DeleteAsync(string name, UserCredentials userCredentials = null)
+```

--- a/dotnet-api/3.5.0/projections.md
+++ b/dotnet-api/3.5.0/projections.md
@@ -1,0 +1,83 @@
+---
+title: "Projections Management"
+section: ".NET API"
+version: "3.5.0"
+---
+
+**PROJECTIONS ARE STILL IN BETA THIS DOCUMENTATION IS SUBJECT TO CHANGE WITHOUT NOTICE
+
+The Event Store Client API includes some helper methods that use the HTTP API to allow for the management of projections in the system. This document will describe the methods found in the ProjectionsManager class (in addition to the XML docs already on it). Note all methods in this class are async.
+
+## Methods
+
+### Enable a Projection
+
+Enables an existing projection by its name. You must have access to a projection in order to enable it.
+
+```csharp
+        public Task EnableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Disable a Projection
+
+Disables an existing projection by its name. You must have access to a projection in order to disable it.
+
+```csharp
+        public Task DisableAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Abort a Projection
+
+Aborts an existing projection by its name. You must have access to a projection in order to abort it.
+
+```csharp
+        public Task AbortAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Create a One-Time Projection
+
+Creates a projection that will run until the end of the log and then stop. The query parameter contains the javascript you want to be created as a one time projection.
+
+```csharp
+        public Task CreateOneTimeAsync(string query, UserCredentials userCredentials = null)
+```
+
+### Create a Continuous Projection
+
+Creates a projection that will run until the end of the log and then continue running. The query parameter contains the javascript you want to be created as a one time projection. Continuous projections have explicit names and can be enabled/disabled via this name
+
+```csharp
+        public Task CreateContinuousAsync(string name, string query, UserCredentials userCredentials = null)
+```
+
+### List all Projections
+
+Returns a list of all the projections in the system.
+
+```csharp
+        public Task<List<ProjectionDetails>> ListAllAsync(UserCredentials userCredentials = null)
+```
+
+### List One-Time Projections
+
+Returns a list of all One-Time Projections in the system
+
+```csharp
+        public Task<List<ProjectionDetails>> ListOneTimeAsync(UserCredentials userCredentials = null)
+```
+
+### Get Statistics on Projection
+
+Returns the statistics associated with a named projection
+
+```csharp
+        public Task<string> GetStatisticsAsync(string name, UserCredentials userCredentials = null)
+```
+
+### Delete Projection
+
+Deletes a named projection. You must have access to a projection in order to delete it.
+
+```csharp
+        public Task DeleteAsync(string name, UserCredentials userCredentials = null)
+```


### PR DESCRIPTION
Update the projections docs version from 3.1.0-pre to 3.1.0
Also change the return value to List<ProjectionDetails> for ListAllAsync and ListOneTimeAsync from version 3.4.0 onwards and remove the TODO statements about changing the return types to objects.