### PR TITLE
Switched to kramdown and rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,10 @@
 title: "Event Store Documentation"
 permalink: pretty
-markdown: redcarpet
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
 
-highlighter: pygments
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 top_level_sections:
     - Introduction


### PR DESCRIPTION
GitHub Pages stop supporting redcarpet and pygments next month. This switches us to the new, default markdown parser (kramdown) and syntax highlighter (rouge).