### PR TITLE
Fix kramdown parsing issues.

### DIFF
--- a/cli/1.0.0/index.md
+++ b/cli/1.0.0/index.md
@@ -44,6 +44,7 @@ The other method of specifying the configuration is to pass them in when perform
 ```
 
 ### Usage
+
 #### Basic Usage
 
 ```

--- a/dotnet-api/3.0.0/writing-to-a-stream.md
+++ b/dotnet-api/3.0.0/writing-to-a-stream.md
@@ -7,9 +7,9 @@ The client API can be used to write one or more events to a stream atomically. T
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.0.1/writing-to-a-stream.md
+++ b/dotnet-api/3.0.1/writing-to-a-stream.md
@@ -8,9 +8,9 @@ The client API can be used to write one or more events to a stream atomically. T
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.0.2/writing-to-a-stream.md
+++ b/dotnet-api/3.0.2/writing-to-a-stream.md
@@ -8,9 +8,9 @@ The client API can be used to write one or more events to a stream atomically. T
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.1.0/writing-to-a-stream.md
+++ b/dotnet-api/3.1.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.2.0/writing-to-a-stream.md
+++ b/dotnet-api/3.2.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.3.1/writing-to-a-stream.md
+++ b/dotnet-api/3.3.1/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.4.0/writing-to-a-stream.md
+++ b/dotnet-api/3.4.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.5.0/writing-to-a-stream.md
+++ b/dotnet-api/3.5.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.6.0/writing-to-a-stream.md
+++ b/dotnet-api/3.6.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/dotnet-api/3.7.0/embedded-client.md
+++ b/dotnet-api/3.7.0/embedded-client.md
@@ -123,7 +123,9 @@ The following options are available when building an Embedded Node
         </tr>
 </tbody>
 </table>
+
 ### Certificate options
+
 <table>
     <thead>
         <tr>
@@ -152,6 +154,7 @@ The following options are available when building an Embedded Node
 </table>
 
 ### Cluster options
+
 <table>
     <thead>
         <tr>
@@ -212,6 +215,7 @@ The following options are available when building an Embedded Node
 </table>
 
 ### Database options
+
 <table>
     <thead>
         <tr>
@@ -288,6 +292,7 @@ The following options are available when building an Embedded Node
 </table>
 
 ### Interface options
+
 <table>
     <thead>
         <tr>
@@ -412,6 +417,7 @@ The following options are available when building an Embedded Node
 </table>
 
 ### Projections options
+
 <table>
     <thead>
         <tr>

--- a/dotnet-api/3.7.0/writing-to-a-stream.md
+++ b/dotnet-api/3.7.0/writing-to-a-stream.md
@@ -8,9 +8,9 @@ TThe client API can be used to write one or more events to a stream atomically. 
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 
-##Methods
+## Methods
 
-###Appending to a stream in a single write
+### Appending to a stream in a single write
 
 ```csharp
 Task AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events)

--- a/http-api/3.0.0/index.md
+++ b/http-api/3.0.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.0.0/reading-streams.md
+++ b/http-api/3.0.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.0.1/index.md
+++ b/http-api/3.0.1/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.0.1/reading-streams.md
+++ b/http-api/3.0.1/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.0.2/index.md
+++ b/http-api/3.0.2/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.0.2/reading-streams.md
+++ b/http-api/3.0.2/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.0.3/index.md
+++ b/http-api/3.0.3/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.0.3/reading-streams.md
+++ b/http-api/3.0.3/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.1.0/index.md
+++ b/http-api/3.1.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.1.0/reading-streams.md
+++ b/http-api/3.1.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.2.0/index.md
+++ b/http-api/3.2.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.2.0/reading-streams.md
+++ b/http-api/3.2.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json` 
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.4.0/index.md
+++ b/http-api/3.4.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.4.0/reading-streams.md
+++ b/http-api/3.4.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json`
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.5.0/index.md
+++ b/http-api/3.5.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.5.0/reading-streams.md
+++ b/http-api/3.5.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json`
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -192,7 +191,7 @@ Keep-Alive: timeout=15,max=100
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.6.0/index.md
+++ b/http-api/3.6.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.6.0/reading-streams.md
+++ b/http-api/3.6.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json`
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/http-api/3.7.0/index.md
+++ b/http-api/3.7.0/index.md
@@ -45,6 +45,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```json
 [
   {
@@ -210,6 +211,7 @@ Below are examples of [writing](../writing-to-a-stream) an event to a stream, as
 ### Writing an event to a stream.
 
 simple-event.txt:
+
 ```xml
 <Events>
   <Event>

--- a/http-api/3.7.0/reading-streams.md
+++ b/http-api/3.7.0/reading-streams.md
@@ -106,6 +106,7 @@ There some important bits to notice here. The Feed here has one item in it. The 
 
 <span class="note">
 The accepted content types for GET requests are currently:
+</span>
 
 - `application/xml`
 - `application/atom+xml`
@@ -113,8 +114,6 @@ The accepted content types for GET requests are currently:
 - `application/vnd.eventstore.atom+json`
 - `text/xml`
 - `text/html`
-
-</span>
 
 ```
 curl -i http://127.0.0.1:2113/streams/newstream2/0 -H "Accept: application/json"
@@ -188,11 +187,12 @@ Keep-Alive: timeout=15,max=100
   ]
 }
 ```
+
 ## Feed Paging
 
 The next thing towards understanding how to read a stream is understanding the first/last/previous/next links that are given within a stream. The basic idea is that the server will give you links so that you can walk through a stream.
 
-To read through the stream we will follow the pattern defined in RFC 5005 http://tools.ietf.org/html/rfc5005.
+To read through the stream we will follow the pattern defined in <a href="http://tools.ietf.org/html/rfc5005">RFC 5005</a>.
 
 In the example above the server had returned as part of its result:
 

--- a/introduction/event-sourcing-basics.md
+++ b/introduction/event-sourcing-basics.md
@@ -226,10 +226,13 @@ The cost is that a developer really needs to be intimately familiar with both th
 > To succeed using objects and relational databases together you need to understand both paradigms, and their differences, and then make intelligent tradeoffs based on that knowledge. <cite>Ambler</cite>
  
 Some of these subtle differences can be found in Wikipedia under the "Object-Relational Impedance Mismatch" page but to include some of the major differences:
+
 >
 > 1.  **Declarative vs. imperative interfaces** Relational thinking tends to use data as interfaces, not behaviour as interfaces. It thus has a declarative tilt in design philosophy in contrast to OO’s behavioural tilt. (Some relational proponents propose using triggers, stored procedures, etc. to provide complex behaviour, but this is not a common viewpoint.) <cite>Object-Relational Impedance Mismatch</cite>
+
 >
 > 2.  **Structure vs. behaviour** - OO primarily focuses on ensuring that the structure of the program is reasonable (maintainable, understandable, extensible, reusable, safe), whereas relational systems focus on what kind of behaviour the resulting run-time system has (efficiency, adaptability, fault-tolerance, liveness, logical integrity, etc.). Object-oriented methods generally assume that the primary user of the object-oriented code and its interfaces are the application developers. In relational systems, the end-user’s view of the behaviour of the system is sometimes considered to be more important. However, relational queries and "views" are common techniques to re-represent information in application- or task-specific configurations. Further, relational does not prohibit local or application-specific structures or tables from being created, although many common development tools do not directly provide such a feature, assuming objects will be used instead. This makes it difficult to know whether the stated non-developer perspective of relational is inherent to relational, or merely a product of current practice and tool implementation assumptions. <cite>Object-Relational Impedance Mismatch</cite>
+
 >
 > 3.  **Set vs. graph relationships** The relationship between different items (objects or records) tend to be handled differently between the paradigms. Relational relationships are usually based on idioms taken from set theory, while object relationships lean toward idioms adopted from graph theory (including trees). While each can represent the same information as the other, the approaches they provide to access and manage information differ. <cite>Object-Relational Impedance Mismatch</cite>
 

--- a/server/3.0.0/cluster-with-manager-nodes.md
+++ b/server/3.0.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.0.0/command-line-arguments.md
+++ b/server/3.0.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+###  Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help <br/>|HELP|Help|Show help. (Default: False)|
@@ -78,12 +79,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec <br/>--stats-period-sec=VALUE|STATSPERIODSEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30)|
 |-WorkerThreads <br/>--worker-threads=VALUE|WORKERTHREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5)|
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType <br/>--authentication-type=VALUE|AUTHENTICATIONTYPE|AuthenticationType|The type of authentication to use. (Default: internal)|
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation <br/>--certificate-store-location=VALUE|CERTIFICATESTORELOCATION|CertificateStoreLocation|The certificate store location name.|
@@ -93,7 +96,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile <br/>--certificate-file=VALUE|CERTIFICATEFILE|CertificateFile|The path to certificate file.|
 |-CertificatePassword <br/>--certificate-password=VALUE|CERTIFICATEPASSWORD|CertificatePassword|The password to certificate in file.|
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize <br/>--cluster-size=VALUE|CLUSTERSIZE|ClusterSize|The number of nodes in the cluster. (Default: 1)|
@@ -108,7 +112,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs <br/>--gossip-allowed-difference-ms=VALUE|GOSSIPALLOWEDDIFFERENCEMS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000)|
 |-GossipTimeoutMs <br/>--gossip-timeout-ms=VALUE|GOSSIPTIMEOUTMS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500)|
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs <br/>--min-flush-delay-ms=VALUE|MINFLUSHDELAYMS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2)|
@@ -123,7 +128,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs <br/>--commit-timeout-ms=VALUE|COMMITTIMEOUTMS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000)|
 |-UnsafeDisableFlushToDisk <br/>--unsafe-disable-flush-to-disk=VALUE|UNSAFEDISABLEFLUSHTODISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False)|
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp <br/>--int-ip=VALUE|INTIP|IntIp|Internal IP Address. (Default: 127.0.0.1)|
@@ -147,7 +153,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost <br/>--ssl-target-host=VALUE|SSLTARGETHOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a)|
 |-SslValidateServer <br/>--ssl-validate-server=VALUE|SSLVALIDATESERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True)|
 
-###Projections Options
+### Projections Options
+
 
 <span class="note--warning">
 Projections are currently a *BETA* feature, you should avoid using them for critical production tasks.

--- a/server/3.0.1/cluster-with-manager-nodes.md
+++ b/server/3.0.1/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.0.1/command-line-arguments.md
+++ b/server/3.0.1/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help <br/>|HELP|Help|Show help. (Default: False)|
@@ -78,12 +79,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec <br/>--stats-period-sec=VALUE|STATSPERIODSEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30)|
 |-WorkerThreads <br/>--worker-threads=VALUE|WORKERTHREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5)|
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType <br/>--authentication-type=VALUE|AUTHENTICATIONTYPE|AuthenticationType|The type of authentication to use. (Default: internal)|
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation <br/>--certificate-store-location=VALUE|CERTIFICATESTORELOCATION|CertificateStoreLocation|The certificate store location name.|
@@ -93,7 +96,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile <br/>--certificate-file=VALUE|CERTIFICATEFILE|CertificateFile|The path to certificate file.|
 |-CertificatePassword <br/>--certificate-password=VALUE|CERTIFICATEPASSWORD|CertificatePassword|The password to certificate in file.|
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize <br/>--cluster-size=VALUE|CLUSTERSIZE|ClusterSize|The number of nodes in the cluster. (Default: 1)|
@@ -108,7 +112,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs <br/>--gossip-allowed-difference-ms=VALUE|GOSSIPALLOWEDDIFFERENCEMS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000)|
 |-GossipTimeoutMs <br/>--gossip-timeout-ms=VALUE|GOSSIPTIMEOUTMS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500)|
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs <br/>--min-flush-delay-ms=VALUE|MINFLUSHDELAYMS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2)|
@@ -123,7 +128,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs <br/>--commit-timeout-ms=VALUE|COMMITTIMEOUTMS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000)|
 |-UnsafeDisableFlushToDisk <br/>--unsafe-disable-flush-to-disk=VALUE|UNSAFEDISABLEFLUSHTODISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False)|
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp <br/>--int-ip=VALUE|INTIP|IntIp|Internal IP Address. (Default: 127.0.0.1)|
@@ -147,7 +153,7 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost <br/>--ssl-target-host=VALUE|SSLTARGETHOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a)|
 |-SslValidateServer <br/>--ssl-validate-server=VALUE|SSLVALIDATESERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True)|
 
-###Projections Options
+### Projections Options
 
 <span class="note--warning">
 Projections are currently a *BETA* feature, you should avoid using them for critical production tasks.

--- a/server/3.0.2/cluster-with-manager-nodes.md
+++ b/server/3.0.2/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.0.2/command-line-arguments.md
+++ b/server/3.0.2/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help <br/>|HELP|Help|Show help. (Default: False)|
@@ -78,12 +79,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec <br/>--stats-period-sec=VALUE|STATSPERIODSEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30)|
 |-WorkerThreads <br/>--worker-threads=VALUE|WORKERTHREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5)|
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType <br/>--authentication-type=VALUE|AUTHENTICATIONTYPE|AuthenticationType|The type of authentication to use. (Default: internal)|
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation <br/>--certificate-store-location=VALUE|CERTIFICATESTORELOCATION|CertificateStoreLocation|The certificate store location name.|
@@ -93,7 +96,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile <br/>--certificate-file=VALUE|CERTIFICATEFILE|CertificateFile|The path to certificate file.|
 |-CertificatePassword <br/>--certificate-password=VALUE|CERTIFICATEPASSWORD|CertificatePassword|The password to certificate in file.|
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize <br/>--cluster-size=VALUE|CLUSTERSIZE|ClusterSize|The number of nodes in the cluster. (Default: 1)|
@@ -108,7 +112,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs <br/>--gossip-allowed-difference-ms=VALUE|GOSSIPALLOWEDDIFFERENCEMS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000)|
 |-GossipTimeoutMs <br/>--gossip-timeout-ms=VALUE|GOSSIPTIMEOUTMS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500)|
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs <br/>--min-flush-delay-ms=VALUE|MINFLUSHDELAYMS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2)|
@@ -123,7 +128,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs <br/>--commit-timeout-ms=VALUE|COMMITTIMEOUTMS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000)|
 |-UnsafeDisableFlushToDisk <br/>--unsafe-disable-flush-to-disk=VALUE|UNSAFEDISABLEFLUSHTODISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False)|
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp <br/>--int-ip=VALUE|INTIP|IntIp|Internal IP Address. (Default: 127.0.0.1)|
@@ -147,7 +153,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost <br/>--ssl-target-host=VALUE|SSLTARGETHOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a)|
 |-SslValidateServer <br/>--ssl-validate-server=VALUE|SSLVALIDATESERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True)|
 
-###Projections Options
+### Projections Options
+
 
 <span class="note--warning">
 Projections are currently a *BETA* feature, you should avoid using them for critical production tasks.

--- a/server/3.0.3/cluster-with-manager-nodes.md
+++ b/server/3.0.3/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.0.3/command-line-arguments.md
+++ b/server/3.0.3/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help <br/>|HELP|Help|Show help. (Default: False)|
@@ -78,12 +79,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec <br/>--stats-period-sec=VALUE|STATSPERIODSEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30)|
 |-WorkerThreads <br/>--worker-threads=VALUE|WORKERTHREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5)|
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType <br/>--authentication-type=VALUE|AUTHENTICATIONTYPE|AuthenticationType|The type of authentication to use. (Default: internal)|
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation <br/>--certificate-store-location=VALUE|CERTIFICATESTORELOCATION|CertificateStoreLocation|The certificate store location name.|
@@ -93,7 +96,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile <br/>--certificate-file=VALUE|CERTIFICATEFILE|CertificateFile|The path to certificate file.|
 |-CertificatePassword <br/>--certificate-password=VALUE|CERTIFICATEPASSWORD|CertificatePassword|The password to certificate in file.|
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize <br/>--cluster-size=VALUE|CLUSTERSIZE|ClusterSize|The number of nodes in the cluster. (Default: 1)|
@@ -108,7 +112,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs <br/>--gossip-allowed-difference-ms=VALUE|GOSSIPALLOWEDDIFFERENCEMS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000)|
 |-GossipTimeoutMs <br/>--gossip-timeout-ms=VALUE|GOSSIPTIMEOUTMS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500)|
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs <br/>--min-flush-delay-ms=VALUE|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2)|
@@ -123,7 +128,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs <br/>--commit-timeout-ms=VALUE|COMMIT_TIMEOUT_MS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000)|
 |-UnsafeDisableFlushToDisk <br/>--unsafe-disable-flush-to-disk=VALUE|UNSAFEDISABLEFLUSHTODISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False)|
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp <br/>--int-ip=VALUE|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1)|
@@ -147,7 +153,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost <br/>--ssl-target-host=VALUE|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a)|
 |-SslValidateServer <br/>--ssl-validate-server=VALUE|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True)|
 
-###Projections Options
+### Projections Options
+
 
 <span class="note--warning">
 Projections are currently a *BETA* feature, you should avoid using them for critical production tasks.

--- a/server/3.0.5/cluster-with-manager-nodes.md
+++ b/server/3.0.5/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.0.5/command-line-arguments.md
+++ b/server/3.0.5/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help <br/>|HELP|Help|Show help. (Default: False)|
@@ -78,12 +79,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec <br/>--stats-period-sec=VALUE|STATSPERIODSEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30)|
 |-WorkerThreads <br/>--worker-threads=VALUE|WORKERTHREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5)|
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType <br/>--authentication-type=VALUE|AUTHENTICATIONTYPE|AuthenticationType|The type of authentication to use. (Default: internal)|
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation <br/>--certificate-store-location=VALUE|CERTIFICATESTORELOCATION|CertificateStoreLocation|The certificate store location name.|
@@ -93,7 +96,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile <br/>--certificate-file=VALUE|CERTIFICATEFILE|CertificateFile|The path to certificate file.|
 |-CertificatePassword <br/>--certificate-password=VALUE|CERTIFICATEPASSWORD|CertificatePassword|The password to certificate in file.|
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize <br/>--cluster-size=VALUE|CLUSTERSIZE|ClusterSize|The number of nodes in the cluster. (Default: 1)|
@@ -108,7 +112,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs <br/>--gossip-allowed-difference-ms=VALUE|GOSSIPALLOWEDDIFFERENCEMS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000)|
 |-GossipTimeoutMs <br/>--gossip-timeout-ms=VALUE|GOSSIPTIMEOUTMS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500)|
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs <br/>--min-flush-delay-ms=VALUE|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2)|
@@ -123,7 +128,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs <br/>--commit-timeout-ms=VALUE|COMMIT_TIMEOUT_MS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000)|
 |-UnsafeDisableFlushToDisk <br/>--unsafe-disable-flush-to-disk=VALUE|UNSAFEDISABLEFLUSHTODISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False)|
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp <br/>--int-ip=VALUE|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1)|
@@ -147,7 +153,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost <br/>--ssl-target-host=VALUE|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a)|
 |-SslValidateServer <br/>--ssl-validate-server=VALUE|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True)|
 
-###Projections Options
+### Projections Options
+
 
 <span class="note--warning">
 Projections are currently a *BETA* feature, you should avoid using them for critical production tasks.

--- a/server/3.1.0/cluster-with-manager-nodes.md
+++ b/server/3.1.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.1.0/cluster-without-manager-nodes.md
+++ b/server/3.1.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.1.0/command-line-arguments.md
+++ b/server/3.1.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -80,12 +81,14 @@ The following parameters are supported by the Event Store:
 |-StatsPeriodSec<br/>--stats-period-sec=VALUE<br/>|STATS_PERIOD_SEC|StatsPeriodSec|The number of seconds between statistics gathers. (Default: 30) |
 |-WorkerThreads<br/>--worker-threads=VALUE<br/>|WORKER_THREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -95,7 +98,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -110,7 +114,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -125,7 +130,8 @@ The following parameters are supported by the Event Store:
 |-CommitTimeoutMs<br/>--commit-timeout-ms=VALUE<br/>|COMMIT_TIMEOUT_MS|CommitTimeoutMs|Commit timeout (in milliseconds). (Default: 2000) |
 |-UnsafeDisableFlushToDisk<br/>--unsafe-disable-flush-to-disk=VALUE<br/>|UNSAFE_DISABLE_FLUSH_TO_DISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -154,7 +160,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of JavaScript projections. (Default: System) Possible Values: None,System,All|

--- a/server/3.2.0/cluster-with-manager-nodes.md
+++ b/server/3.2.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.2.0/cluster-without-manager-nodes.md
+++ b/server/3.2.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.2.0/command-line-arguments.md
+++ b/server/3.2.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -81,12 +82,14 @@ The following parameters are supported by the Event Store:
 |-WorkerThreads<br/>--worker-threads=VALUE<br/>|WORKER_THREADS|WorkerThreads|The number of threads to use for pool of worker services. (Default: 5) |
 |-EnableHistograms<br/>--enable-histograms=VALUE<br/>|ENABLE_HISTOGRAMS|EnableHistograms|Enables the tracking of various histograms in the backend, typically only used for debugging etc. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -96,7 +99,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -111,7 +115,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -127,7 +132,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeDisableFlushToDisk<br/>--unsafe-disable-flush-to-disk=VALUE<br/>|UNSAFE_DISABLE_FLUSH_TO_DISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -159,7 +165,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of JavaScript projections. (Default: System) Possible Values: None,System,All|

--- a/server/3.3.0/cluster-with-manager-nodes.md
+++ b/server/3.3.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.3.0/cluster-without-manager-nodes.md
+++ b/server/3.3.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.3.0/command-line-arguments.md
+++ b/server/3.3.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -82,12 +83,14 @@ The following parameters are supported by the Event Store:
 |-DisableHTTPCaching<br/>--disable-http-caching=VALUE<br/>|DISABLE_HTTP_CACHING|DisableHTTPCaching|Disables HTTP Caching. (Default: False) |
 |-StartStandardProjections<br/>--start-standard-projections=VALUE<br/>|START_STANDARD_PROJECTIONS|StartStandardProjections|Starts the Standard Projections if system projections are enabled. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -97,7 +100,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -112,7 +116,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -128,7 +133,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeDisableFlushToDisk<br/>--unsafe-disable-flush-to-disk=VALUE<br/>|UNSAFE_DISABLE_FLUSH_TO_DISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -162,7 +168,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of JavaScript projections. (Default: System) Possible Values: None,System,All|

--- a/server/3.4.0/cluster-with-manager-nodes.md
+++ b/server/3.4.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.4.0/cluster-without-manager-nodes.md
+++ b/server/3.4.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.4.0/command-line-arguments.md
+++ b/server/3.4.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -82,12 +83,14 @@ The following parameters are supported by the Event Store:
 |-DisableHTTPCaching<br/>--disable-http-caching=VALUE<br/>|DISABLE_HTTP_CACHING|DisableHTTPCaching|Disables HTTP Caching. (Default: False) |
 |-StartStandardProjections<br/>--start-standard-projections=VALUE<br/>|START_STANDARD_PROJECTIONS|StartStandardProjections|Starts the Standard Projections if system projections are enabled. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -97,7 +100,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -112,7 +116,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift between clocks on nodes allowed before gossip is rejected in ms. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout on gossip to another node in ms. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -128,7 +133,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeDisableFlushToDisk<br/>--unsafe-disable-flush-to-disk=VALUE<br/>|UNSAFE_DISABLE_FLUSH_TO_DISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -162,7 +168,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of JavaScript projections. (Default: System) Possible Values: None,System,All|

--- a/server/3.5.0/cluster-with-manager-nodes.md
+++ b/server/3.5.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.5.0/cluster-without-manager-nodes.md
+++ b/server/3.5.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.5.0/command-line-arguments.md
+++ b/server/3.5.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -83,13 +84,15 @@ The following parameters are supported by the Event Store:
 |-EnableHistograms<br/>--enable-histograms=VALUE<br/>|ENABLE_HISTOGRAMS|EnableHistograms|Enables the tracking of various histograms in the backend, typically only used for debugging etc (Default: False) |
 |-LogHttpRequests<br/>--log-http-requests=VALUE<br/>|LOG_HTTP_REQUESTS|LogHttpRequests|Log Http Requests and Responses before processing them. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 |-AuthenticationConfig<br/>--authentication-config=VALUE<br/>|AUTHENTICATION_CONFIG|AuthenticationConfig|Path to the configuration file for authentication configuration (if applicable). |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -99,7 +102,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -114,7 +118,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift, in ms, between clocks on nodes allowed before gossip is rejected. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout, in ms, on gossip to another node. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -132,7 +137,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeDisableFlushToDisk<br/>--unsafe-disable-flush-to-disk=VALUE<br/>|UNSAFE_DISABLE_FLUSH_TO_DISK|UnsafeDisableFlushToDisk|Disable flushing to disk.  (UNSAFE: on power off) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -166,7 +172,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of projections. System runs built-in projections, All runs user projections. (Default: None) Possible Values:None,System,All|

--- a/server/3.5.0/ports-and-networking.md
+++ b/server/3.5.0/ports-and-networking.md
@@ -24,7 +24,7 @@ The internal tcp and http are configured similarly to the external. All internal
 
 When setting up a cluster the nodes must be able to reach each other over both the internal http channel and the internal tcp channel. You should ensure that these ports are open on firewalls etc both on the machines and between the machines.
 
-##Heartbeat Timeouts
+## Heartbeat Timeouts
 
 Event Store uses heartbeats over all tcp connections to attempt to discover dead clients/nodes. Setting heartbeat timeouts can be tricky, set them too short and you will get false positives, set them too long and discovery of dead clients/nodes becomes slower.
 
@@ -34,7 +34,7 @@ Varying environments want drastically different values for these settings. While
 
 *If in question error on the side of higher numbers, it will only add a small period of time to discover a dead client/node and is likely better than the alternative which is false positives.*
 
-##Advertise As
+## Advertise As
 
 There are times when due to NAT or other reasons a node may not be bound to the address it is actually reachable from other nodes as. As an example the machine could have an ip address of 192.168.1.13 but the node is visible to other nodes as 10.114.12.112.
 

--- a/server/3.6.0/cluster-with-manager-nodes.md
+++ b/server/3.6.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.6.0/cluster-without-manager-nodes.md
+++ b/server/3.6.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.6.0/command-line-arguments.md
+++ b/server/3.6.0/command-line-arguments.md
@@ -65,7 +65,8 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
@@ -83,13 +84,15 @@ The following parameters are supported by the Event Store:
 |-EnableHistograms<br/>--enable-histograms=VALUE<br/>|ENABLE_HISTOGRAMS|EnableHistograms|Enables the tracking of various histograms in the backend, typically only used for debugging etc (Default: False) |
 |-LogHttpRequests<br/>--log-http-requests=VALUE<br/>|LOG_HTTP_REQUESTS|LogHttpRequests|Log Http Requests and Responses before processing them. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 |-AuthenticationConfig<br/>--authentication-config=VALUE<br/>|AUTHENTICATION_CONFIG|AuthenticationConfig|Path to the configuration file for authentication configuration (if applicable). |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -99,7 +102,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -114,7 +118,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift, in ms, between clocks on nodes allowed before gossip is rejected. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout, in ms, on gossip to another node. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -134,7 +139,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeIgnoreHardDelete<br/>--unsafe-ignore-hard-delete=VALUE<br/>|UNSAFE_IGNORE_HARD_DELETE|UnsafeIgnoreHardDelete|Disables Hard Deletes (UNSAFE: use to remove hard deletes) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -168,7 +174,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of projections. System runs built-in projections, All runs user projections. (Default: None) Possible Values:None,System,All|

--- a/server/3.6.0/ports-and-networking.md
+++ b/server/3.6.0/ports-and-networking.md
@@ -24,7 +24,7 @@ The internal tcp and http are configured similarly to the external. All internal
 
 When setting up a cluster the nodes must be able to reach each other over both the internal http channel and the internal tcp channel. You should ensure that these ports are open on firewalls etc both on the machines and between the machines.
 
-##Heartbeat Timeouts
+## Heartbeat Timeouts
 
 Event Store uses heartbeats over all tcp connections to attempt to discover dead clients/nodes. Setting heartbeat timeouts can be tricky, set them too short and you will get false positives, set them too long and discovery of dead clients/nodes becomes slower.
 
@@ -34,7 +34,7 @@ Varying environments want drastically different values for these settings. While
 
 *If in question error on the side of higher numbers, it will only add a small period of time to discover a dead client/node and is likely better than the alternative which is false positives.*
 
-##Advertise As
+## Advertise As
 
 There are times when due to NAT or other reasons a node may not be bound to the address it is actually reachable from other nodes as. As an example the machine could have an ip address of 192.168.1.13 but the node is visible to other nodes as 10.114.12.112.
 

--- a/server/3.7.0/cluster-with-manager-nodes.md
+++ b/server/3.7.0/cluster-with-manager-nodes.md
@@ -11,7 +11,7 @@ Event Store allows several nodes to be run as a cluster, in order to achieve hig
 
 This document covers setting up Event Store with manager nodes and database nodes.
 
-##Manager Nodes
+## Manager Nodes
 
 Each physical (or virtual) machine in an Event Store cluster typically runs one manager node and one database node. It is also possible to have multiple database nodes per physical machine, running under one manager node.
 
@@ -22,7 +22,7 @@ Manager nodes have a number of responsibilities:
 - They provide a known endpoint for clients to connect to to discover cluster information.
 - When running on Windows, manager nodes run as Windows services.
 
-##Configuring Nodes
+## Configuring Nodes
 
 Each database or manager node can have a variety of configuration sources. Each source has a priority, and running configuration is determined by evaluating each source and then applying the option from the source with the highest priority.
 
@@ -35,7 +35,7 @@ From lowest to highest priority, the sources of configuration are:
 
 The effective configuration of a node can be determined by passing the `-WhatIf` flag to the process.
 
-##Typical Deployment Topologies
+## Typical Deployment Topologies
 
 Event Store clusters follow a "shared nothing" philiosophy. This means that no shared disks are required in order for clustering to work. Instead, several database nodes store your data in order to ensure that it is not lost in the case of a drive failure or a node crashing.
 
@@ -43,13 +43,13 @@ A quorum-based replication model is used, in which a majority of nodes in the cl
 
 A typical deployment topology consists of three physical machines, each running one manager node and one database node, as shown in figure 1. Each of the physical machines may have two network interfaces - one for communicating with other cluster members, and one for serving clients. Although it may be preferable in some situations to run over two separate networks, it is also possible to use different TCP ports on one interface.
 
-##Cluster gossip
+## Cluster gossip
 
 Event Store uses a quorum-based replication model. When working normally, a cluster will have one database node which is known as a *master*, and the remaining nodes will be *slaves*. The master node is responsible for co-ordinating writes during the period it is master. Database nodes use a concensus algorithm to determine which database node should be master and which should be slaves. The decision as to which node should be master is based on a number of factors (some of which are configurable).
 
 In order for database nodes to have this information available to them, the nodes gossip with other nodes in the cluster. Gossip runs over the internal and optionally the external HTTP interfaces of database nodes, and over both internal and external interfaces of manager nodes.
 
-##Discovering cluster members
+## Discovering cluster members
 
 Manager and database nodes need to know about one another in order to gossip. To bootstrap this process, gossip seeds, or the addresses where some other nodes may be found, must be provided to each node. When running with manager nodes, the following approach is normally used:
 
@@ -160,7 +160,7 @@ For the first node in the example cluster, the watchdog configuration file reads
 # --config c:\EventStore-Config\database.yaml
 ```
 
-### Deploying the Event Store software and configuration
+### Deploying the Event Store software and configuration
 
 Having written configuration files for each node, the software and configuration can be deployed. Although it is possible to use relative paths when writing configuration files, it is preferable to use absolute paths to reduce the potential for confusion.
 

--- a/server/3.7.0/cluster-without-manager-nodes.md
+++ b/server/3.7.0/cluster-without-manager-nodes.md
@@ -8,7 +8,7 @@ Effective September of 2013 all of the clustering code for Event Store has been 
 
 When setting up a cluster you will generally want an odd number of nodes. This is due to the fact that the Event Store uses a quorum based algorithm to handle high availability. 
 
-##Running on Same Machine
+## Running on Same Machine
 
 To start with we will set up three nodes running on a single machine run each command in its own console window, remember that you either need admin privileges or have setup ACLs with IIS if running in windows (no configuration should be needed in Unix-like operating systems). Replace "127.0.0.1" with whatever IP address you want to run on. Note that this must be an interface actually present on the machine.
 

--- a/server/3.7.0/command-line-arguments.md
+++ b/server/3.7.0/command-line-arguments.md
@@ -65,12 +65,13 @@ User projections are not enabled by default, however the projections engine is u
 
 The following parameters are supported by the Event Store:
 
-###Application Options
+### Application Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-Help<br/>--help=VALUE<br/>|HELP|Help|Show help. (Default: False) |
 |-Version<br/>--version=VALUE<br/>|VERSION|Version|Show version. (Default: False) |
-|-Log<br/>--log=VALUE<br/>|LOG|Log|Path where to keep log files. (Default: /Users/pieterg/source/EventStore/tools/documentation-generation/logs) |
+|-Log<br/>--log=VALUE<br/>|LOG|Log|Path where to keep log files. (Default: /Users/hayleyc/Documents/Code/eventstore/EventStore/etc/EventStore.Documentation/bin/Debug/logs) |
 |-Config<br/>--config=VALUE<br/>|CONFIG|Config|Configuration files. |
 |-Defines<br/>--defines=VALUE<br/>|DEFINES|Defines|Run-time conditionals. (Default: n/a) |
 |-WhatIf<br/>--what-if=VALUE<br/>|WHAT_IF|WhatIf|Print effective configuration to console and then exit. (Default: False) |
@@ -83,13 +84,15 @@ The following parameters are supported by the Event Store:
 |-EnableHistograms<br/>--enable-histograms=VALUE<br/>|ENABLE_HISTOGRAMS|EnableHistograms|Enables the tracking of various histograms in the backend, typically only used for debugging etc (Default: False) |
 |-LogHttpRequests<br/>--log-http-requests=VALUE<br/>|LOG_HTTP_REQUESTS|LogHttpRequests|Log Http Requests and Responses before processing them. (Default: False) |
 
-###Authentication Options
+### Authentication Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-AuthenticationType<br/>--authentication-type=VALUE<br/>|AUTHENTICATION_TYPE|AuthenticationType|The type of authentication to use. (Default: internal) |
 |-AuthenticationConfig<br/>--authentication-config=VALUE<br/>|AUTHENTICATION_CONFIG|AuthenticationConfig|Path to the configuration file for authentication configuration (if applicable). |
 
-###Certificate Options
+### Certificate Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-CertificateStoreLocation<br/>--certificate-store-location=VALUE<br/>|CERTIFICATE_STORE_LOCATION|CertificateStoreLocation|The certificate store location name. |
@@ -99,7 +102,8 @@ The following parameters are supported by the Event Store:
 |-CertificateFile<br/>--certificate-file=VALUE<br/>|CERTIFICATE_FILE|CertificateFile|The path to certificate file. |
 |-CertificatePassword<br/>--certificate-password=VALUE<br/>|CERTIFICATE_PASSWORD|CertificatePassword|The password to certificate in file. |
 
-###Cluster Options
+### Cluster Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-ClusterSize<br/>--cluster-size=VALUE<br/>|CLUSTER_SIZE|ClusterSize|The number of nodes in the cluster. (Default: 1) |
@@ -114,7 +118,8 @@ The following parameters are supported by the Event Store:
 |-GossipAllowedDifferenceMs<br/>--gossip-allowed-difference-ms=VALUE<br/>|GOSSIP_ALLOWED_DIFFERENCE_MS|GossipAllowedDifferenceMs|The amount of drift, in ms, between clocks on nodes allowed before gossip is rejected. (Default: 60000) |
 |-GossipTimeoutMs<br/>--gossip-timeout-ms=VALUE<br/>|GOSSIP_TIMEOUT_MS|GossipTimeoutMs|The timeout, in ms, on gossip to another node. (Default: 500) |
 
-###Database Options
+### Database Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-MinFlushDelayMs<br/>--min-flush-delay-ms=VALUE<br/>|MIN_FLUSH_DELAY_MS|MinFlushDelayMs|The minimum flush delay in milliseconds. (Default: 2) |
@@ -123,7 +128,7 @@ The following parameters are supported by the Event Store:
 |-CachedChunks<br/>--cached-chunks=VALUE<br/>|CACHED_CHUNKS|CachedChunks|The number of chunks to cache in unmanaged memory. (Default: -1) |
 |-ChunksCacheSize<br/>--chunks-cache-size=VALUE<br/>|CHUNKS_CACHE_SIZE|ChunksCacheSize|The amount of unmanaged memory to use for caching chunks. (Default: 536871424) |
 |-MaxMemTableSize<br/>--max-mem-table-size=VALUE<br/>|MAX_MEM_TABLE_SIZE|MaxMemTableSize|Adjusts the maximum size of a mem table. (Default: 1000000) |
-|-Db<br/>--db=VALUE<br/>|DB|Db|The path the db should be loaded/saved to. (Default: /Users/pieterg/source/EventStore/tools/documentation-generation/data) |
+|-Db<br/>--db=VALUE<br/>|DB|Db|The path the db should be loaded/saved to. (Default: /Users/hayleyc/Documents/Code/eventstore/EventStore/etc/EventStore.Documentation/bin/Debug/data) |
 |-Index<br/>--index=VALUE<br/>|INDEX|Index|The path the index should be loaded/saved to. |
 |-MemDb<br/>--mem-db=VALUE<br/>|MEM_DB|MemDb|Keep everything in memory, no directories or files are created. (Default: False) |
 |-SkipDbVerify<br/>--skip-db-verify=VALUE<br/>|SKIP_DB_VERIFY|SkipDbVerify|Bypasses the checking of file hashes of database during startup (allows for faster startup). (Default: False) |
@@ -134,7 +139,8 @@ The following parameters are supported by the Event Store:
 |-UnsafeIgnoreHardDelete<br/>--unsafe-ignore-hard-delete=VALUE<br/>|UNSAFE_IGNORE_HARD_DELETE|UnsafeIgnoreHardDelete|Disables Hard Deletes (UNSAFE: use to remove hard deletes) (Default: False) |
 |-IndexCacheDepth<br/>--index-cache-depth=VALUE<br/>|INDEX_CACHE_DEPTH|IndexCacheDepth|Sets the depth to cache for the mid point cache in index. (Default: 16) |
 
-###Interface Options
+### Interface Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-IntIp<br/>--int-ip=VALUE<br/>|INT_IP|IntIp|Internal IP Address. (Default: 127.0.0.1) |
@@ -168,7 +174,8 @@ The following parameters are supported by the Event Store:
 |-SslTargetHost<br/>--ssl-target-host=VALUE<br/>|SSL_TARGET_HOST|SslTargetHost|Target host of server's SSL certificate. (Default: n/a) |
 |-SslValidateServer<br/>--ssl-validate-server=VALUE<br/>|SSL_VALIDATE_SERVER|SslValidateServer|Whether to validate that server's certificate is trusted. (Default: True) |
 
-###Projections Options
+### Projections Options
+
 | Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |
 | --------- | --------------------------------------------- | ---- | ----------- |
 |-RunProjections<br/>--run-projections=VALUE<br/>|RUN_PROJECTIONS|RunProjections|Enables the running of projections. System runs built-in projections, All runs user projections. (Default: None) Possible Values:None,System,All|

--- a/server/3.7.0/ports-and-networking.md
+++ b/server/3.7.0/ports-and-networking.md
@@ -24,7 +24,7 @@ The internal tcp and http are configured similarly to the external. All internal
 
 When setting up a cluster the nodes must be able to reach each other over both the internal http channel and the internal tcp channel. You should ensure that these ports are open on firewalls etc both on the machines and between the machines.
 
-##Heartbeat Timeouts
+## Heartbeat Timeouts
 
 Event Store uses heartbeats over all tcp connections to attempt to discover dead clients/nodes. Setting heartbeat timeouts can be tricky, set them too short and you will get false positives, set them too long and discovery of dead clients/nodes becomes slower.
 
@@ -34,7 +34,7 @@ Varying environments want drastically different values for these settings. While
 
 *If in question error on the side of higher numbers, it will only add a small period of time to discover a dead client/node and is likely better than the alternative which is false positives.*
 
-##Advertise As
+## Advertise As
 
 There are times when due to NAT or other reasons a node may not be bound to the address it is actually reachable from other nodes as. As an example the machine could have an ip address of 192.168.1.13 but the node is visible to other nodes as 10.114.12.112.
 


### PR DESCRIPTION
Kramdown is stricter than the markdown parser we were using previously, and requires correct spacing to parse markdown correctly.