### PR TITLE
Add mention of "picoFeed"

### DIFF
--- a/http-api/3.9.0/reading-streams.md
+++ b/http-api/3.9.0/reading-streams.md
@@ -10,17 +10,17 @@ The Event Store is compliant with the [Atom 1.0 Specification](http://tools.ietf
 
 ## Existing Implementations
 
-| Library     | Description                                                                                          |
-| ----------- | ---------------------------------------------------------------------------------------------------- |
-| NET (BCL)   | `System.ServiceModel.SyndicationServices`                                                            |
-| JVM         | [http://java-source.net/open-source/rss-rdf-tools](http://java-source.net/open-source/rss-rdf-tools) |
-| PHP         | [http://simplepie.org/](http://simplepie.org/)                                                       |
-| Ruby        | [http://simple-rss.rubyforge.org](http://simple-rss.rubyforge.org)                                   |
-| Clojure     | [https://github.com/scsibug/feedparser-clj](https://github.com/scsibug/feedparser-clj)               |
-| Go          | [https://github.com/jteeuwen/go-pkg-rss](https://github.com/jteeuwen/go-pkg-rss)                     |
-| Python      | [http://code.google.com/p/feedparser/](http://code.google.com/p/feedparser/)                         |
-| node.js     | [https://github.com/danmactough/node-feedparser](https://github.com/danmactough/node-feedparser)     |
-| Objective C | [https://geekli.st/darvin/repos/MWFeedParser](https://geekli.st/darvin/repos/MWFeedParser)           |
+| Library     | Description                                                                                                                                                      |
+| ----------- | ----------------------------------------------------------------------------------------------------                                                              |
+| NET (BCL)   | `System.ServiceModel.SyndicationServices`                                                                                                                        |
+| JVM         | [http://java-source.net/open-source/rss-rdf-tools](http://java-source.net/open-source/rss-rdf-tools)                                                              |
+| PHP         | [http://simplepie.org/](http://simplepie.org/) or [https://github.com/fguillot/picoFeed](https://github.com/fguillot/picoFeed) |
+| Ruby        | [http://simple-rss.rubyforge.org](http://simple-rss.rubyforge.org)                                                                                                |
+| Clojure     | [https://github.com/scsibug/feedparser-clj](https://github.com/scsibug/feedparser-clj)                                                                            |
+| Go          | [https://github.com/jteeuwen/go-pkg-rss](https://github.com/jteeuwen/go-pkg-rss)                                                                                  |
+| Python      | [http://code.google.com/p/feedparser/](http://code.google.com/p/feedparser/)                                                                                      |
+| node.js     | [https://github.com/danmactough/node-feedparser](https://github.com/danmactough/node-feedparser)                                                                  |
+| Objective C | [https://geekli.st/darvin/repos/MWFeedParser](https://geekli.st/darvin/repos/MWFeedParser)                                                                        |
 
 <span class="note--warning">
 The above list of implementations are not officially supported by Event Store, if you know of any others then please let us know.


### PR DESCRIPTION
Because this library is more up-to-date with good practices.
