### PR TITLE
Updates name of macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# OS X
+# macOS
 .DS_Store
 .AppleDouble
 .LSOverride

--- a/server/3.0.0/index.md
+++ b/server/3.0.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.0.1/index.md
+++ b/server/3.0.1/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.0.2/index.md
+++ b/server/3.0.2/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,4 +62,4 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.

--- a/server/3.0.3/index.md
+++ b/server/3.0.3/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.0.5/index.md
+++ b/server/3.0.5/index.md
@@ -9,7 +9,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -54,9 +54,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -64,7 +64,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.1.0/default-directories.md
+++ b/server/3.1.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.1.0/index.md
+++ b/server/3.1.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.2.0/default-directories.md
+++ b/server/3.2.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.2.0/index.md
+++ b/server/3.2.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113/
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.3.0/default-directories.md
+++ b/server/3.3.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.3.0/index.md
+++ b/server/3.3.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.4.0/default-directories.md
+++ b/server/3.4.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.4.0/index.md
+++ b/server/3.4.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.5.0/default-directories.md
+++ b/server/3.5.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.5.0/index.md
+++ b/server/3.5.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.6.0/default-directories.md
+++ b/server/3.6.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.6.0/index.md
+++ b/server/3.6.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.7.0/default-directories.md
+++ b/server/3.7.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.7.0/index.md
+++ b/server/3.7.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.8.0/default-directories.md
+++ b/server/3.8.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.8.0/index.md
+++ b/server/3.8.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.8.1/default-directories.md
+++ b/server/3.8.1/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.8.1/index.md
+++ b/server/3.8.1/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/3.9.0/default-directories.md
+++ b/server/3.9.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/3.9.0/index.md
+++ b/server/3.9.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 

--- a/server/4.0.0/default-directories.md
+++ b/server/4.0.0/default-directories.md
@@ -22,7 +22,7 @@ Paths beginning with "." are relative to the directory in which "eventstored" or
 - **Projections:** `./projections` *then* `{Content}/projections`
 - **Prelude:** `./Prelude` *then* `{Content}/Prelude`
 
-### All other OSes (Includes Windows/OSX) ###
+### All other OSes (Includes Windows/macOS) ###
 - **Content:** `./`
 - **Configuration:** `./`
 - **Data:** `./data`

--- a/server/4.0.0/index.md
+++ b/server/4.0.0/index.md
@@ -7,7 +7,7 @@ pinned: true
 
 The Event Store runs as a server, to which clients can connect either over HTTP or using one of the client APIs. Both the open source, and commercial versions, can be run as either a single node, or a highly available cluster of nodes.
 
-The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/OS X on Mono.
+The [open source version of Event Store](https://geteventstore.com/downloads) is distributed as a console application. There are separate distributions for Windows on .NET and Linux/macOS on Mono.
 
 ## Running the Open Source version
 
@@ -52,9 +52,9 @@ netsh http delete urlacl http://+:2113
 
 This should resolve the issue.
 
-### On Linux/OS X
+### On Linux/macOS
 
-A typical command line for running the Event Store server on Linux/OS X is:
+A typical command line for running the Event Store server on Linux/macOS is:
 
 ```
 $ ./run-node.sh --db ./ESData
@@ -62,7 +62,7 @@ $ ./run-node.sh --db ./ESData
 
 Although you can run the Event Store binary directly, a `run-node` shell script is provided which exports the environment variable `LD_LIBRARY_PATH` to include the installation path of the Event Store, this is necessary if you are planning to use projections.
 
-The Event Store builds for both Linux and OS X have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
+The Event Store builds for both Linux and macOS have the Mono runtime bundled in, this means that you do not need Mono installed locally to run Event Store.
 
 ### Shutting down an Event Store node
 


### PR DESCRIPTION
Apple renamed Mac OS X to macOS last year. This commit updates our
references to the OS to use the correct name.