### PR TITLE
Remove extraneous </code> from api concurrency docs

### DIFF
--- a/dotnet-api/3.0.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.0.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.0.1/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.0.1/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.0.2/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.0.2/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.1.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.1.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.2.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.2.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.3.1/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.3.1/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.4.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.4.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.5.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.5.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.6.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.6.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>this specifies the expectation that target stream does not yet exist.</code></td>
+            <td>this specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.8.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.8.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>This specifies the expectation that target stream does not yet exist.</code></td>
+            <td>This specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/3.9.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/3.9.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>This specifies the expectation that target stream does not yet exist.</code></td>
+            <td>This specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>

--- a/dotnet-api/4.0.0/optimistic-concurrency-and-idempotence.md
+++ b/dotnet-api/4.0.0/optimistic-concurrency-and-idempotence.md
@@ -22,7 +22,7 @@ In the .NET API, there are a number of constants which should be used to represe
         </tr>
         <tr>
             <td><code>ExpectedVersion.NoStream</code></td>
-            <td>This specifies the expectation that target stream does not yet exist.</code></td>
+            <td>This specifies the expectation that target stream does not yet exist.</td>
         </tr>
         <tr>
             <td><code>ExpectedVersion.EmptyStream</code></td>


### PR DESCRIPTION
Hi guys just noticed this [in the docs](http://docs.geteventstore.com/dotnet-api/4.0.0/optimistic-concurrency-and-idempotence/) & bothered me enough to contribute :grin: thanks for a great project.