### PR TITLE
Correcting projections docs for fromStreamsMatching

### DIFF
--- a/projections/4.0.0/user-defined-projections.md
+++ b/projections/4.0.0/user-defined-projections.md
@@ -151,17 +151,14 @@ fromStream('account-1') //selector
             <td>
             	<b>Provides</b>
             	<ul>
-	            	<li>partitionBy</li>
 	            	<li>when</li>
-	            	<li>foreachStream</li>
-	            	<li>outputState</li>
             	</ul>
             </td>
         </tr>
 	</tbody>
 </table>
 
-# Filters/Transormations
+# Filters/Transformations
 
 <table>
     <thead>


### PR DESCRIPTION
According to [1Prelude.js](https://github.com/EventStore/EventStore/blob/c0cb775ff875ebf1580a18c9126eb6d6a9259fff/src/EventStore.Projections.Core/Prelude/1Prelude.js#L196) `fromStreamsMatching` only provides `when` - updating the docs to reflect this (and fixing a minor typo)