### PR TITLE
Fixes minor typo on the "writing-to-a-stream.md" files.

### DIFF
--- a/dotnet-api/3.1.0/writing-to-a-stream.md
+++ b/dotnet-api/3.1.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.1.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.2.0/writing-to-a-stream.md
+++ b/dotnet-api/3.2.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.2.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.3.1/writing-to-a-stream.md
+++ b/dotnet-api/3.3.1/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.3.1"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.4.0/writing-to-a-stream.md
+++ b/dotnet-api/3.4.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.4.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.5.0/writing-to-a-stream.md
+++ b/dotnet-api/3.5.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.5.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.6.0/writing-to-a-stream.md
+++ b/dotnet-api/3.6.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.6.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.7.0/writing-to-a-stream.md
+++ b/dotnet-api/3.7.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.7.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.8.0/writing-to-a-stream.md
+++ b/dotnet-api/3.8.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.8.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/3.9.0/writing-to-a-stream.md
+++ b/dotnet-api/3.9.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "3.9.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 

--- a/dotnet-api/4.0.0/writing-to-a-stream.md
+++ b/dotnet-api/4.0.0/writing-to-a-stream.md
@@ -4,7 +4,7 @@ section: ".NET API"
 version: "4.0.0"
 ---
 
-TThe client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
+The client API can be used to write one or more events to a stream atomically. This can be done either by appending the events to the stream in one operation, or by starting a transaction on the stream, writing events in one or more operations in that transaction, and then committing the transaction.
 
 An optimistic concurrency check can be made during the write by specifying the version at which the stream is expected to be currently. Identical write operations are idempotent if the optimistic concurrency check is not disabled. More information on optimistic concurrency and idempotence can be found [here](../optimistic-concurrency-and-idempotence).
 


### PR DESCRIPTION
The beginning of the sentence starts of with a minor typo. I Removed the extra "t" on the "The" for the sentence starting with "The client API can be used to write one or more events to a stream atomically". 