### PR TITLE
Remove `s` and `e` from `$init` examples.

### DIFF
--- a/_wiki-orphans/projections/Projection-RESTful-Api.md
+++ b/_wiki-orphans/projections/Projection-RESTful-Api.md
@@ -8,7 +8,7 @@ To create a query in the system you just post the javascript of the query to the
 ouro@ouroboros:>cat projection.txt
 fromAll().
     when({
-       $init : function(s,e) {return {count : 0}},
+       $init : function() {return {count : 0}},
        $any  : function(s,e) {return {count : s.count +1}}
     })
 ```

--- a/_wiki-orphans/projections/Projections-when.md
+++ b/_wiki-orphans/projections/Projections-when.md
@@ -15,7 +15,7 @@ append foo MyType1 {'foo' : 'data4'}
 
 q fromStream('foo').
      when({
-        $init   : function(s,e) { return { mt1 : 0, mt3 : 0}},
+        $init   : function() { return { mt1 : 0, mt3 : 0}},
         MyType1 : function(s,e) { return { mt1 : s.mt1 + 1, mt3 : s.mt3}},
         MyType3 : function(s,e) { return { mt1 : s.mt1, mt3 : s.mt3 + 1}}
      })
@@ -39,7 +39,7 @@ es:> append foo MyType1 {'foo' : 'data4'}
 Succeeded.
 es:> q fromStream('foo').
      when({
-        $init   : function(s,e) { return { mt1 : 0, mt3 : 0}},
+        $init   : function() { return { mt1 : 0, mt3 : 0}},
         MyType1 : function(s,e) { return { mt1 : s.mt1 + 1, mt3 : s.mt3}},
         MyType3 : function(s,e) { return { mt1 : s.mt1, mt3 : s.mt3 + 1}}
      })
@@ -57,7 +57,7 @@ This query has three pattern matches inside of it.
 
 ```js
      when({
-        $init   : function(s,e) { return { mt1 : 0, mt3 : 0}},
+        $init   : function() { return { mt1 : 0, mt3 : 0}},
         MyType1 : function(s,e) { return { mt1 : s.mt1 + 1, mt3 : s.mt3}},
         MyType3 : function(s,e) { return { mt1 : s.mt1, mt3 : s.mt3 + 1}}
      })

--- a/projections/4.0.0/debugging.md
+++ b/projections/4.0.0/debugging.md
@@ -41,7 +41,7 @@ Contents:
 ```json
 fromStream('$stats-127.0.0.1:2113')
 .when({
-    $init: function(s,e){
+    $init: function(){
         return {
             count: 0
         }

--- a/projections/4.0.0/getting-started.md
+++ b/projections/4.0.0/getting-started.md
@@ -182,7 +182,7 @@ Contents:
 ```json
 fromAll()
 .when({
-    $init: function(s,e){
+    $init: function(){
         return {
             count: 0
         }
@@ -243,7 +243,7 @@ Filename: `xbox-one-s-counter-outputState.json`
 ```json
 fromAll()
 .when({
-    $init: function(s,e){
+    $init: function(){
         return {
             count: 0
         }
@@ -316,7 +316,7 @@ Filename: `shopping-cart-counter.json`
 fromCategory('shoppingCart')
 .foreachStream()
 .when({
-    $init: function(s,e){
+    $init: function(){
         return {
             count: 0
         }
@@ -327,7 +327,7 @@ fromCategory('shoppingCart')
 })
 ```
 
-Once again, we can create the projection by issing an HTTP request
+Once again, we can create the projection by issuing an HTTP request
 
 ```bash
 curl -i --data-binary "@shopping-cart-counter.json" http://localhost:2113/projections/continuous?name=shopping-cart-item-counter%26type=js%26enabled=true%26emit=true%26trackemittedstreams=true -u admin:changeit

--- a/projections/4.0.0/user-defined-projections.md
+++ b/projections/4.0.0/user-defined-projections.md
@@ -19,7 +19,7 @@ options({ //option
 
 fromStream('account-1') //selector
 .when({ //filter
-	$init:function(state, evnt){
+	$init:function(){
 		return {
 			count: 0
 		}


### PR DESCRIPTION
Unless I'm mistaken, from my debugging, they seem to always come through
as `undefined`.

Also fix typo "issing" -> "issuing".