### PR TITLE
Minor: update markdown language hint from "json" to "javascript"...

### DIFF
--- a/projections/4.0.0/debugging.md
+++ b/projections/4.0.0/debugging.md
@@ -15,7 +15,7 @@ Something that proves to be quite useful is printing out the structure of the ev
 
 For example:
 
-```bash
+```javascript
 fromStream('$stats-127.0.0.1:2113')
 .when({
     $any: function(s,e){
@@ -38,7 +38,7 @@ Filename: `stats-counter.json`
 
 Contents:
 
-```json
+```javascript
 fromStream('$stats-127.0.0.1:2113')
 .when({
     $init: function(){

--- a/projections/4.0.0/getting-started.md
+++ b/projections/4.0.0/getting-started.md
@@ -179,7 +179,7 @@ Filename: `xbox-one-s-counter.json`
 
 Contents:
 
-```json
+```javascript
 fromAll()
 .when({
     $init: function(){
@@ -240,7 +240,7 @@ We could configure the projection to output the state to a stream by calling the
 
 Filename: `xbox-one-s-counter-outputState.json`
 
-```json
+```javascript
 fromAll()
 .when({
     $init: function(){
@@ -312,7 +312,7 @@ We will make use of the built in system projection `$by_category` that will enab
 
 Filename: `shopping-cart-counter.json`
 
-```json
+```javascript
 fromCategory('shoppingCart')
 .foreachStream()
 .when({

--- a/projections/4.0.0/user-defined-projections.md
+++ b/projections/4.0.0/user-defined-projections.md
@@ -9,7 +9,7 @@ User defined projections are written in javascript (ECMASCRIPT 6).
 
 Example projection:
 
-```
+```javascript
 options({ //option
 	resultStreamName: "my_demo_projection_result",
 	$includeLinks: false,


### PR DESCRIPTION
where appropriate. This should cause better highlighting through the
markdown engine.

I say "should" because I can't seem to get Jekyll running on my machine correctly... Not sure why.

Here's an example of how github handles the two
(hinted as `json`)
```json
 fromStream('$stats-127.0.0.1:2113')
 .when({
     $init: function(){
         return {
             count: 0
         }
     },
     $any: function(s,e){
         s.count += 1;
     }
 })
 ```
(and as `javascript`)
```javascript
 fromStream('$stats-127.0.0.1:2113')
 .when({
     $init: function(){
         return {
             count: 0
         }
     },
     $any: function(s,e){
         s.count += 1;
     }
 })
 ```