### PR TITLE
Add documentation for `filterBy`.

### DIFF
--- a/projections/4.0.2/user-defined-projections.md
+++ b/projections/4.0.2/user-defined-projections.md
@@ -228,6 +228,19 @@ fromStream('account-1') //selector
             	</ul>
             </td>
         </tr>
+        <tr>
+            <td><code>filterBy(function(state))</code></td>
+            <td>Causes projection results to be `null` for any `state` that returns a falsey value from the given predicate.</td>
+            <td>
+            	<b>Provides</b>
+            	<ul>
+	            	<li>transformBy</li>
+	            	<li>filterBy</li>
+	            	<li>outputState</li>
+	            	<li>outputTo</li>
+            	</ul>
+            </td>
+        </tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
I noticed `filterBy` wasn't documented anywhere.

I based the docs on the [specs](https://github.com/EventStore/EventStore/blob/ec8ec115d14ca59ec3677209fb81942ce81d314b/src/EventStore.Projections.Core.Tests/Services/v8/when_defining_a_v8_projection.cs#L383) and the [JS prelude](https://github.com/EventStore/EventStore/blob/ec8ec115d14ca59ec3677209fb81942ce81d314b/src/EventStore.Projections.Core/Prelude/1Prelude.js#L106).