### PR TITLE
Document `eventType` projection event envelope property.

### DIFF
--- a/projections/4.0.0/user-defined-projections.md
+++ b/projections/4.0.0/user-defined-projections.md
@@ -244,6 +244,7 @@ The event provided through the handler contains the following properties.
 - metadataRaw: {}
 - linkMetadataRaw: string
 - partition: string
+- eventType: string
 
 <table>
     <thead>

--- a/projections/4.0.2/user-defined-projections.md
+++ b/projections/4.0.2/user-defined-projections.md
@@ -9,7 +9,7 @@ User defined projections are written in javascript (ECMASCRIPT 6).
 
 Example projection:
 
-```
+```javascript
 options({ //option
 	resultStreamName: "my_demo_projection_result",
 	$includeLinks: false,
@@ -257,6 +257,7 @@ The event provided through the handler contains the following properties.
 - metadataRaw: {}
 - linkMetadataRaw: string
 - partition: string
+- eventType: string
 
 <table>
     <thead>


### PR DESCRIPTION
This may not seem super useful at first glance but I've used it a few
times now (having manually inspected the envelope and discovered it).

It's particularly useful for projections with `$any` for example, we use
one like this at my work
```javascript
fromAll()
  .when({
    $init: () => ({
      eventTypes: {},
      handled: 0
    }),
    $any: (s, e) => {
      s.eventTypes[e.eventType] = (s.eventTypes[e.eventType] || 0) + 1;
      s.handled++;
    }
  });
```

Also sneak in a `javascript` language hint on projection code.