### PR TITLE
Add Golang TCP Community Developed Clients

### DIFF
--- a/introduction/which-api.md
+++ b/introduction/which-api.md
@@ -28,6 +28,7 @@ A low level protocol is offered in the form of an asynchronous TCP protocol that
 -   [Python](https://github.com/madedotcom/atomicpuppy)
 -   [Java8](https://github.com/msemys/esjc)
 -   [Maven plugin](https://github.com/fuinorg/event-store-maven-plugin)
+-   [Go](https://github.com/jdextraze/go-gesclient)
 
 ## HTTP
 


### PR DESCRIPTION
I have been working on this TCP client for Go for more than 2 years now. It has been used in production with no issue since last year. I am also actively maintaining it.